### PR TITLE
fix(sql-parser): correctly parse column names that are keywords

### DIFF
--- a/packages/sql-ddl-parser/package.json
+++ b/packages/sql-ddl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vuerd/sql-ddl-parser",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "description": "Permissive SQL DDL Parser",
   "main": "dist/sql-ddl-parser.js",
   "module": "dist/sql-ddl-parser.esm.js",

--- a/packages/sql-ddl-parser/package.json
+++ b/packages/sql-ddl-parser/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "test": "jest src/SQLParser.spec.ts"
+    "test": "jest src/SQLParser.spec.ts src/tests/SQLParser.test.ts"
   },
   "author": "dineug <dineug2@gmail.com>",
   "license": "MIT"

--- a/packages/sql-ddl-parser/package.json
+++ b/packages/sql-ddl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vuerd/sql-ddl-parser",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Permissive SQL DDL Parser",
   "main": "dist/sql-ddl-parser.js",
   "module": "dist/sql-ddl-parser.esm.js",

--- a/packages/sql-ddl-parser/package.json
+++ b/packages/sql-ddl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vuerd/sql-ddl-parser",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Permissive SQL DDL Parser",
   "main": "dist/sql-ddl-parser.js",
   "module": "dist/sql-ddl-parser.esm.js",

--- a/packages/sql-ddl-parser/src/SQLParser.spec.ts
+++ b/packages/sql-ddl-parser/src/SQLParser.spec.ts
@@ -33,5 +33,5 @@ setupCase();
 it.each(testCaseList)('%s', (_, sql, json) => {
   const tokens = tokenizer(sql);
   const statements = parser(tokens);
-  expect(json).toEqual({ statements });
+  expect({statements}).toEqual(json);
 });

--- a/packages/sql-ddl-parser/src/SQL_DDL_Test_Case.md
+++ b/packages/sql-ddl-parser/src/SQL_DDL_Test_Case.md
@@ -756,6 +756,118 @@ CREATE TABLE b (
   ]
 }
 ```
+### Column double FOREIGN KEY
+
+```sql
+CREATE TABLE users (
+  id int NOT NULL PRIMARY KEY AUTO_INCREMENT UNIQUE,
+)
+CREATE TABLE posts (
+  id int NOT NULL PRIMARY KEY AUTO_INCREMENT UNIQUE,
+)
+CREATE TABLE comments (
+  id int NOT NULL PRIMARY KEY AUTO_INCREMENT UNIQUE,
+  userId int NOT NULL,
+  postId int NOT NULL
+  CONSTRAINT author FOREIGN KEY(userId) REFERENCES users (id) ON DELETE CASCADE
+  CONSTRAINT post FOREIGN KEY(postId) REFERENCES posts (id) ON DELETE CASCADE
+)
+```
+
+```json
+{
+  "statements": [
+    {
+      "type": "create.table",
+      "name": "users",
+      "comment": "",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": true,
+          "autoIncrement": true,
+          "unique": true,
+          "nullable": false
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    },
+    {
+      "type": "create.table",
+      "name": "posts",
+      "comment": "",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": true,
+          "autoIncrement": true,
+          "unique": true,
+          "nullable": false
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    },
+    {
+      "type": "create.table",
+      "name": "comments",
+      "comment": "",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": true,
+          "autoIncrement": true,
+          "unique": true,
+          "nullable": false
+        },
+        {
+          "name": "userId",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "postId",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": [
+        {
+          "columnNames": ["userId"],
+          "refTableName": "users",
+          "refColumnNames": ["id"]
+        },
+        {
+          "columnNames": ["postId"],
+          "refTableName": "posts",
+          "refColumnNames": ["id"]
+        }
+      ]
+    }
+  ]
+}
+```
 
 ### CREATE INDEX
 

--- a/packages/sql-ddl-parser/src/sqlParser/SQLParserHelper.ts
+++ b/packages/sql-ddl-parser/src/sqlParser/SQLParserHelper.ts
@@ -130,7 +130,6 @@ export function isNewStatement(token?: Token): boolean {
     keywordEqual(token, 'DROP') ||
     keywordEqual(token, 'USE') ||
     keywordEqual(token, 'RENAME') ||
-    keywordEqual(token, 'DELETE') ||
     keywordEqual(token, 'SELECT')
   );
 }

--- a/packages/sql-ddl-parser/src/sqlParser/create.table.ts
+++ b/packages/sql-ddl-parser/src/sqlParser/create.table.ts
@@ -54,9 +54,11 @@ export function createTable(tokens: Token[]): CreateTable {
         tokens,
         current
       );
-      ast.columns = columns;
-      ast.indexes = indexes;
-      ast.foreignKeys = foreignKeys;
+      if (ast.columns.length === 0) {
+        ast.columns = columns;
+        ast.indexes = indexes;
+        ast.foreignKeys = foreignKeys;
+      }
       continue;
     }
 

--- a/packages/sql-ddl-parser/src/sqlParser/create.table.ts
+++ b/packages/sql-ddl-parser/src/sqlParser/create.table.ts
@@ -316,6 +316,9 @@ function createTableColumns(
         current.value++;
       }
 
+      if (column.dataType && !column.name) {
+        column.name = column.dataType;
+      }
       column.dataType = value;
       continue;
     }

--- a/packages/sql-ddl-parser/src/tests/SQLParser.test.ts
+++ b/packages/sql-ddl-parser/src/tests/SQLParser.test.ts
@@ -14,4 +14,22 @@ describe('parsing edge cases', () => {
     const actualColumns = firstStatement.columns.map(column => column.name);
     expect(actualColumns).toEqual(expectedColumns);
   });
+  test('when column name is a keyword', () => {
+    const ddl = `  CREATE TABLE "CMS03"."TA040_ATT_CLU"
+    (	"C_AMB" VARCHAR2(6 BYTE),
+   "C_ATT_CLU" VARCHAR2(7 BYTE),
+    ) SEGMENT CREATION IMMEDIATE
+   PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255
+  NOCOMPRESS LOGGING
+   STORAGE(INITIAL 65536 NEXT 1048576 MINEXTENTS 1 MAXEXTENTS 2147483645
+   PCTINCREASE 0 FREELISTS 1 FREELIST GROUPS 1
+   BUFFER_POOL DEFAULT FLASH_CACHE DEFAULT CELL_FLASH_CACHE DEFAULT)
+   TABLESPACE "TS_CMS03_DAT" ;
+ `;
+    const expectedColumns = ['C_AMB', 'C_ATT_CLU'];
+    const parsedResult = DDLParser(ddl);
+    const firstStatement = parsedResult[0] as CreateTable;
+    const actualColumns = firstStatement.columns.map(column => column.name);
+    expect(actualColumns).toEqual(expectedColumns);
+  });
 });

--- a/packages/sql-ddl-parser/src/tests/SQLParser.test.ts
+++ b/packages/sql-ddl-parser/src/tests/SQLParser.test.ts
@@ -1,0 +1,17 @@
+import { DDLParser } from '@/SQLParser';
+import { CreateTable } from '@@types/index';
+
+describe('parsing edge cases', () => {
+  test('when column name is a keyword', () => {
+    const ddl = `create table MY_TABLE (
+      name          number,
+      uuid          number,
+      integer       number,
+    );`;
+    const expectedColumns = ['name', 'uuid', 'integer'];
+    const parsedResult = DDLParser(ddl);
+    const firstStatement = parsedResult[0] as CreateTable;
+    const actualColumns = firstStatement.columns.map(column => column.name);
+    expect(actualColumns).toEqual(expectedColumns);
+  });
+});


### PR DESCRIPTION
As mentioned in https://github.com/vuerd/vuerd/issues/293, there is an issue with column names that are keywords.

This PR tackles the problem by adding a check on data type parsing: if a type is already set for this column, then that was the name of the column, mistaken as its type, and the newly found type is the real type.

**Side note**: the issue is caused by the parser not being aware of the order of things: in DDL we always (as far as I know) have the column name _before_ the type, so this assumption should be safe to do, and a possible improvement on stability and edge-cases management could be done by introducing some kind of ordering logic, but this is out of the scope of this PR.