### PR TITLE
fix(erd-editor): Qualify a unique constraint name with its table

### DIFF
--- a/packages/erd-editor/src/utils/schema-sql/MSSQL.test.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MSSQL.test.ts
@@ -167,7 +167,7 @@ describe('MSSQL createSchema', () => {
         'GO',
         '',
         'ALTER TABLE users',
-        '  ADD CONSTRAINT UQ_email UNIQUE (email)',
+        '  ADD CONSTRAINT UQ_users_email UNIQUE (email)',
         'GO',
         '',
         "EXECUTE sys.sp_addextendedproperty 'MS_Description',",
@@ -277,6 +277,23 @@ describe('MSSQL createSchema', () => {
         '',
       ].join('\n')
     );
+  });
+
+  it('qualifies a unique constraint with its table so two tables can share a column name', () => {
+    const { state, posts } = createFixture();
+    state.collections.tableColumnEntities['c-post-email'] = createColumn({
+      id: 'c-post-email',
+      tableId: 't-posts',
+      name: 'email',
+      dataType: 'VARCHAR(255)',
+      options: ColumnOption.unique,
+    });
+    posts.columnIds.push('c-post-email');
+
+    const sql = createSchema(state);
+
+    expect(sql).toContain('  ADD CONSTRAINT UQ_users_email UNIQUE (email)');
+    expect(sql).toContain('  ADD CONSTRAINT UQ_posts_email UNIQUE (email)');
   });
 });
 

--- a/packages/erd-editor/src/utils/schema-sql/MSSQL.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MSSQL.ts
@@ -61,7 +61,7 @@ export function createSchema(state: RootState): string {
       uqColumns.forEach(column => {
         stringBuffer.push(`ALTER TABLE ${bracket}${table.name}${bracket}`);
         stringBuffer.push(
-          `  ADD CONSTRAINT ${bracket}UQ_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket})\nGO`
+          `  ADD CONSTRAINT ${bracket}UQ_${table.name}_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket})\nGO`
         );
         stringBuffer.push('');
       });

--- a/packages/erd-editor/src/utils/schema-sql/MariaDB.test.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MariaDB.test.ts
@@ -316,7 +316,7 @@ describe('schema-sql/MariaDB', () => {
         ") COMMENT 'user table';",
         '',
         'ALTER TABLE users',
-        '  ADD CONSTRAINT UQ_name UNIQUE (name);',
+        '  ADD CONSTRAINT UQ_users_name UNIQUE (name);',
         '',
         'ALTER TABLE posts',
         '  ADD CONSTRAINT FK_users_TO_posts',
@@ -380,8 +380,27 @@ describe('schema-sql/MariaDB', () => {
       const sql = createSchema(state);
 
       expect(sql).toContain('ALTER TABLE `users`\n');
-      expect(sql).toContain('  ADD CONSTRAINT `UQ_name` UNIQUE (`name`);\n');
+      expect(sql).toContain(
+        '  ADD CONSTRAINT `UQ_users_name` UNIQUE (`name`);\n'
+      );
       expect(sql).toContain('    REFERENCES `users` (`id`);\n');
+    });
+
+    it('qualifies a unique constraint with its table so two tables can share a column name', () => {
+      const { state, posts } = createFixture();
+      state.collections.tableColumnEntities['col-post-name'] = createColumn({
+        id: 'col-post-name',
+        tableId: 'tbl-posts',
+        name: 'name',
+        dataType: 'VARCHAR(50)',
+        options: ColumnOption.unique,
+      });
+      posts.columnIds.push('col-post-name');
+
+      const sql = createSchema(state);
+
+      expect(sql).toContain('  ADD CONSTRAINT UQ_users_name UNIQUE (name);\n');
+      expect(sql).toContain('  ADD CONSTRAINT UQ_posts_name UNIQUE (name);\n');
     });
 
     it('produces byte-identical output to the MySQL generator', () => {

--- a/packages/erd-editor/src/utils/schema-sql/MariaDB.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MariaDB.ts
@@ -60,7 +60,7 @@ export function createSchema(state: RootState): string {
       uqColumns.forEach(column => {
         stringBuffer.push(`ALTER TABLE ${bracket}${table.name}${bracket}`);
         stringBuffer.push(
-          `  ADD CONSTRAINT ${bracket}UQ_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
+          `  ADD CONSTRAINT ${bracket}UQ_${table.name}_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
         );
         stringBuffer.push('');
       });

--- a/packages/erd-editor/src/utils/schema-sql/MySQL.test.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MySQL.test.ts
@@ -315,7 +315,7 @@ describe('schema-sql/MySQL', () => {
         ") COMMENT 'user table';",
         '',
         'ALTER TABLE users',
-        '  ADD CONSTRAINT UQ_name UNIQUE (name);',
+        '  ADD CONSTRAINT UQ_users_name UNIQUE (name);',
         '',
         'ALTER TABLE posts',
         '  ADD CONSTRAINT FK_users_TO_posts',
@@ -379,8 +379,27 @@ describe('schema-sql/MySQL', () => {
       const sql = createSchema(state);
 
       expect(sql).toContain('ALTER TABLE `users`\n');
-      expect(sql).toContain('  ADD CONSTRAINT `UQ_name` UNIQUE (`name`);\n');
+      expect(sql).toContain(
+        '  ADD CONSTRAINT `UQ_users_name` UNIQUE (`name`);\n'
+      );
       expect(sql).toContain('    REFERENCES `users` (`id`);\n');
+    });
+
+    it('qualifies a unique constraint with its table so two tables can share a column name', () => {
+      const { state, posts } = createFixture();
+      state.collections.tableColumnEntities['col-post-name'] = createColumn({
+        id: 'col-post-name',
+        tableId: 'tbl-posts',
+        name: 'name',
+        dataType: 'VARCHAR(50)',
+        options: ColumnOption.unique,
+      });
+      posts.columnIds.push('col-post-name');
+
+      const sql = createSchema(state);
+
+      expect(sql).toContain('  ADD CONSTRAINT UQ_users_name UNIQUE (name);\n');
+      expect(sql).toContain('  ADD CONSTRAINT UQ_posts_name UNIQUE (name);\n');
     });
   });
 });

--- a/packages/erd-editor/src/utils/schema-sql/MySQL.ts
+++ b/packages/erd-editor/src/utils/schema-sql/MySQL.ts
@@ -60,7 +60,7 @@ export function createSchema(state: RootState): string {
       uqColumns.forEach(column => {
         stringBuffer.push(`ALTER TABLE ${bracket}${table.name}${bracket}`);
         stringBuffer.push(
-          `  ADD CONSTRAINT ${bracket}UQ_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
+          `  ADD CONSTRAINT ${bracket}UQ_${table.name}_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
         );
         stringBuffer.push('');
       });

--- a/packages/erd-editor/src/utils/schema-sql/Oracle.test.ts
+++ b/packages/erd-editor/src/utils/schema-sql/Oracle.test.ts
@@ -162,7 +162,7 @@ describe('Oracle createSchema', () => {
         ');',
         '',
         'ALTER TABLE users',
-        '  ADD CONSTRAINT UQ_email UNIQUE (email);',
+        '  ADD CONSTRAINT UQ_users_email UNIQUE (email);',
         '',
         'CREATE SEQUENCE SEQ_users',
         'START WITH 1',
@@ -336,6 +336,23 @@ describe('Oracle createSchema', () => {
         '',
       ].join('\n')
     );
+  });
+
+  it('qualifies a unique constraint with its table so two tables can share a column name', () => {
+    const { state, posts } = createFixture();
+    state.collections.tableColumnEntities['c-post-email'] = createColumn({
+      id: 'c-post-email',
+      tableId: 't-posts',
+      name: 'email',
+      dataType: 'VARCHAR(255)',
+      options: ColumnOption.unique,
+    });
+    posts.columnIds.push('c-post-email');
+
+    const sql = createSchema(state);
+
+    expect(sql).toContain('  ADD CONSTRAINT UQ_users_email UNIQUE (email);\n');
+    expect(sql).toContain('  ADD CONSTRAINT UQ_posts_email UNIQUE (email);\n');
   });
 });
 

--- a/packages/erd-editor/src/utils/schema-sql/Oracle.ts
+++ b/packages/erd-editor/src/utils/schema-sql/Oracle.ts
@@ -63,7 +63,7 @@ export function createSchema(state: RootState): string {
       uqColumns.forEach(column => {
         stringBuffer.push(`ALTER TABLE ${bracket}${table.name}${bracket}`);
         stringBuffer.push(
-          `  ADD CONSTRAINT ${bracket}UQ_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
+          `  ADD CONSTRAINT ${bracket}UQ_${table.name}_${column.name}${bracket} UNIQUE (${bracket}${column.name}${bracket});`
         );
         stringBuffer.push('');
       });


### PR DESCRIPTION
Integrates #402, #403, #404, #405 and #406 by merging each contributor branch, then adds the test work they need.

## The bug

`createSchema` names every unique constraint `UQ_<column>`. When two tables each carry a unique column of the same name, the generated DDL emits that name twice.

- **Oracle / MSSQL** scope constraint names to the schema — the second `ALTER TABLE` fails outright.
- **MySQL / MariaDB** scope them per table, so it runs but reads as ambiguous.

`UQ_<table>_<column>` fixes all four. PostgreSQL and SQLite emit an inline `UNIQUE` and need no change.

## What is here

| Commits | |
| --- | --- |
| 5 merge commits | @HidekiCofema's original one-line change per dialect, unmodified. #403 and #406 carry the identical Oracle change; both merge cleanly |
| `test(erd-editor)` | The six assertions that spell the old name, plus one new case per dialect: two tables sharing a unique column name must produce two distinct constraint names |

Without the source change those four new tests fail, along with the six updated ones — 10 failures across the four suites.

## Verification

- `vp run --filter @dineug/erd-editor test` — 318 files, 3817 tests pass
- `pnpm check` — format, lint, root `tsc --noEmit`, task-inputs all clean
- `pnpm build` — all 26 tasks pass

## Merging

Please use **Create a merge commit**. Squash or rebase rewrites the contributor commits, and #402–#406 would then have to be closed by hand instead of being marked merged automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
