### PR TITLE
fix(erd-editor): Keep the indexes panel's checkbox column in step with its selection

### DIFF
--- a/packages/erd-editor/e2e/specs/table-properties-indexes.spec.ts
+++ b/packages/erd-editor/e2e/specs/table-properties-indexes.spec.ts
@@ -1,0 +1,140 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../support/fixtures';
+import { ErdEditorPage } from '../support/ErdEditorPage';
+import { createSchema } from '../support/schema';
+import { Shortcut } from '../support/shortcuts';
+
+/**
+ * The panel carries no test ids, so every locator here is structural:
+ * `[title="Add Index"]` is the "+" button, `input[placeholder="name"]` an
+ * index row's name field,
+ * `input[type="checkbox"]` exists only in the checkbox column, and
+ * `[draggable="true"][data-id]` is a row of the lower-right selected-column list.
+ */
+
+const schema = () =>
+  createSchema({
+    tables: [
+      {
+        id: 'student',
+        name: 'student',
+        x: 160,
+        y: 160,
+        columns: [
+          { id: 'student_id', name: 'id', dataType: 'int' },
+          { id: 'student_name', name: 'name', dataType: 'varchar(255)' },
+          { id: 'student_age', name: 'age', dataType: 'int' },
+        ],
+      },
+    ],
+  });
+
+/** Opens Table Properties on one table through the real gesture. */
+async function openProperties(erd: ErdEditorPage, page: Page, table: string) {
+  await erd.clickTableHeader(table);
+  await expect(erd.selectedTables()).toHaveCount(1);
+  await erd.focusHost();
+  await erd.expectKeyboardFocusInside();
+  await erd.press(Shortcut.tableProperties);
+
+  const panel = page.locator('erd-editor .table-properties');
+  await expect(panel).toBeVisible();
+
+  const locators = {
+    panel,
+    addIndex: panel.locator('[title="Add Index"]'),
+    indexNames: panel.locator('input[placeholder="name"]'),
+    checkboxes: panel.locator('input[type="checkbox"]'),
+    selectedColumns: panel.locator('[draggable="true"][data-id]'),
+  };
+  await expect(locators.addIndex).toBeVisible();
+  return locators;
+}
+
+async function openIndexesTab(erd: ErdEditorPage, page: Page) {
+  await erd.seed(schema());
+  const locators = await openProperties(erd, page, 'student');
+  // The Indexes tab is the panel's default.
+  await expect(locators.checkboxes).toHaveCount(3);
+  return locators;
+}
+
+/** What the browser paints is the `checked` property, never the attribute. */
+const checkedStates = (panel: ReturnType<Page['locator']>) =>
+  panel
+    .locator('input[type="checkbox"]')
+    .evaluateAll(inputs => inputs.map(input => input.matches(':checked')));
+
+test.describe('table properties — indexes tab', () => {
+  test('rebinds the checkbox column when the selection moves to another index', async ({
+    erd,
+    page,
+  }) => {
+    const { panel, addIndex, indexNames, checkboxes, selectedColumns } =
+      await openIndexesTab(erd, page);
+
+    await addIndex.click();
+    await expect(indexNames).toHaveCount(1);
+    await indexNames.nth(0).click();
+
+    await checkboxes.nth(0).click();
+    await expect(selectedColumns).toHaveCount(1);
+    await expect(selectedColumns.nth(0)).toContainText('id');
+    await expect.poll(() => checkedStates(panel)).toEqual([true, false, false]);
+
+    await addIndex.click();
+    await expect(indexNames).toHaveCount(2);
+
+    // Adding on its own changes nothing: the first index is still selected.
+    await expect(selectedColumns).toHaveCount(1);
+    await expect.poll(() => checkedStates(panel)).toEqual([true, false, false]);
+
+    await indexNames.nth(1).click();
+    await expect(selectedColumns).toHaveCount(0);
+    await expect
+      .poll(() => checkedStates(panel))
+      .toEqual([false, false, false]);
+
+    await indexNames.nth(0).click();
+    await expect(selectedColumns).toHaveCount(1);
+    await expect.poll(() => checkedStates(panel)).toEqual([true, false, false]);
+  });
+
+  test('adds the column on the first click after switching index', async ({
+    erd,
+    page,
+  }) => {
+    const { panel, addIndex, indexNames, checkboxes, selectedColumns } =
+      await openIndexesTab(erd, page);
+
+    await addIndex.click();
+    await expect(indexNames).toHaveCount(1);
+    await indexNames.nth(0).click();
+    await checkboxes.nth(0).click();
+    await expect(selectedColumns).toHaveCount(1);
+
+    await addIndex.click();
+    await expect(indexNames).toHaveCount(2);
+    await indexNames.nth(1).click();
+    await expect(selectedColumns).toHaveCount(0);
+
+    await checkboxes.nth(0).click();
+    await expect(selectedColumns).toHaveCount(1);
+    await expect(selectedColumns.nth(0)).toContainText('id');
+    await expect.poll(() => checkedStates(panel)).toEqual([true, false, false]);
+
+    // `schema.ts` leaves the two index collections untyped, so read them here.
+    const { collections, doc } = await erd.value();
+    const [, secondIndexId] = doc.indexIds;
+    const { indexColumnIds } = collections.indexEntities[
+      secondIndexId
+    ] as Record<'indexColumnIds', string[]>;
+    const indexColumn = collections.indexColumnEntities[
+      indexColumnIds[0]
+    ] as Record<'columnId', string>;
+
+    expect(indexColumnIds).toHaveLength(1);
+    expect(indexColumn.columnId).toBe('student_id');
+  });
+});

--- a/packages/erd-editor/e2e/specs/table-properties-indexes.spec.ts
+++ b/packages/erd-editor/e2e/specs/table-properties-indexes.spec.ts
@@ -7,8 +7,8 @@ import { Shortcut } from '../support/shortcuts';
 
 /**
  * The panel carries no test ids, so every locator here is structural:
- * `[title="Add Index"]` is the "+" button, `input[placeholder="name"]` an
- * index row's name field,
+ * `[title="Add Index"]` is the "+" button, `[title="<table name>"]` a table tab,
+ * `input[placeholder="name"]` an index row's name field,
  * `input[type="checkbox"]` exists only in the checkbox column, and
  * `[draggable="true"][data-id]` is a row of the lower-right selected-column list.
  */
@@ -26,6 +26,13 @@ const schema = () =>
           { id: 'student_name', name: 'name', dataType: 'varchar(255)' },
           { id: 'student_age', name: 'age', dataType: 'int' },
         ],
+      },
+      {
+        id: 'course',
+        name: 'course',
+        x: 700,
+        y: 160,
+        columns: [{ id: 'course_code', name: 'code', dataType: 'int' }],
       },
     ],
   });
@@ -47,6 +54,7 @@ async function openProperties(erd: ErdEditorPage, page: Page, table: string) {
     indexNames: panel.locator('input[placeholder="name"]'),
     checkboxes: panel.locator('input[type="checkbox"]'),
     selectedColumns: panel.locator('[draggable="true"][data-id]'),
+    tableTab: (name: string) => panel.locator(`[title="${name}"]`),
   };
   await expect(locators.addIndex).toBeVisible();
   return locators;
@@ -136,5 +144,40 @@ test.describe('table properties — indexes tab', () => {
 
     expect(indexColumnIds).toHaveLength(1);
     expect(indexColumn.columnId).toBe('student_id');
+  });
+
+  test('stops applying the index selection once the panel switches table', async ({
+    erd,
+    page,
+  }) => {
+    await erd.seed(schema());
+
+    // Open both tables once, so the panel's tab strip lists the two of them.
+    await openProperties(erd, page, 'student');
+    await erd.press(Shortcut.stop);
+    const { addIndex, indexNames, checkboxes, selectedColumns, tableTab } =
+      await openProperties(erd, page, 'course');
+
+    await tableTab('student').click();
+    await expect(checkboxes).toHaveCount(3);
+
+    await addIndex.click();
+    await expect(indexNames).toHaveCount(1);
+    await indexNames.nth(0).click();
+    await checkboxes.nth(0).click();
+    await expect(selectedColumns).toHaveCount(1);
+
+    // `course` has no index at all, so nothing can be selected while it shows.
+    await tableTab('course').click();
+    await expect(indexNames).toHaveCount(0);
+    await expect(checkboxes).toHaveCount(1);
+    await expect(checkboxes.nth(0)).toBeDisabled();
+    await expect(selectedColumns).toHaveCount(0);
+
+    // Scoped out while `course` shows, not erased.
+    await tableTab('student').click();
+    await expect(indexNames).toHaveCount(1);
+    await expect(selectedColumns).toHaveCount(1);
+    await expect(selectedColumns.nth(0)).toContainText('id');
   });
 });

--- a/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.test.ts
+++ b/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.test.ts
@@ -1,4 +1,4 @@
-import { html } from '@dineug/r-html';
+import { FC, html, observable } from '@dineug/r-html';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
 import {
@@ -12,7 +12,10 @@ import * as indexColumnStyles from '@/components/erd/table-properties/table-prop
 import * as indexStyles from '@/components/erd/table-properties/table-properties-indexes/indexes-index/IndexesIndex.styles';
 import TablePropertiesIndexes from '@/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes';
 import * as styles from '@/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.styles';
-import { addIndexAction } from '@/engine/modules/index/atom.actions';
+import {
+  addIndexAction,
+  removeIndexAction,
+} from '@/engine/modules/index/atom.actions';
 import { addTableAction } from '@/engine/modules/table/atom.actions';
 import { addColumnAction } from '@/engine/modules/table-column/atom.actions';
 
@@ -21,6 +24,23 @@ const OTHER_TABLE_ID = 't2';
 
 const template = (tableId = TABLE_ID) =>
   html`<${TablePropertiesIndexes} tableId=${tableId} />`;
+
+/**
+ * Mirrors `Erd.tsx`: the table tab strip swaps `tableId` while the panel — and
+ * with it whatever this component has selected — stays mounted.
+ */
+const Host: FC = () => {
+  const hostState = observable({ tableId: TABLE_ID });
+  const handleSwitchTable = () => {
+    hostState.tableId =
+      hostState.tableId === TABLE_ID ? OTHER_TABLE_ID : TABLE_ID;
+  };
+
+  return () => html`
+    <div class="switch-table" @click=${handleSwitchTable}></div>
+    <${TablePropertiesIndexes} tableId=${hostState.tableId} />
+  `;
+};
 
 /**
  * `IndexesIndex.styles.row` and `Column.styles.root` declare the same top level
@@ -70,7 +90,10 @@ function seed(app: AppContext) {
     addTableAction({ id: TABLE_ID, ui: { x: 0, y: 0, zIndex: 2 } }),
     addTableAction({ id: OTHER_TABLE_ID, ui: { x: 0, y: 0, zIndex: 3 } })
   );
-  store.dispatchSync(addColumnAction({ id: 'c1', tableId: TABLE_ID }));
+  store.dispatchSync(
+    addColumnAction({ id: 'c1', tableId: TABLE_ID }),
+    addColumnAction({ id: 'c2', tableId: OTHER_TABLE_ID })
+  );
 }
 
 let app: AppContext;
@@ -228,6 +251,74 @@ describe('TablePropertiesIndexes', () => {
       expect(indexColumnRootOf(mounted)).toBeNull();
       expect(checkboxesOf(mounted)[0].disabled).toBe(true);
       expect(checkboxesOf(mounted)[0].checked).toBe(false);
+    });
+  });
+
+  describe('selection outliving what it points at', () => {
+    beforeEach(() => {
+      app.store.dispatchSync(addIndexAction({ id: 'i1', tableId: TABLE_ID }));
+    });
+
+    const switchTable = (mounted: Mounted) =>
+      click(mounted.container.querySelector('.switch-table') as HTMLElement);
+
+    it('stops applying the selection once the panel switches table', async () => {
+      mounted = await mountAndFlush(html`<${Host} />`, app);
+
+      click(indexRowsOf(mounted)[0]);
+      await flush();
+      expect(indexColumnRootOf(mounted)).toBeTruthy();
+
+      switchTable(mounted);
+      await flush();
+
+      expect(indexRowsOf(mounted)).toHaveLength(0);
+      expect(indexColumnRootOf(mounted)).toBeNull();
+      expect(checkboxesOf(mounted)[0].disabled).toBe(true);
+
+      // The selection is scoped out while the other table shows, not erased.
+      switchTable(mounted);
+      await flush();
+
+      expect(indexColumnRootOf(mounted)).toBeTruthy();
+      expect(
+        indexRowsOf(mounted).map(row => row.classList.contains('selected'))
+      ).toEqual([true]);
+    });
+
+    it('cannot put a column of the new table into the previous table index', async () => {
+      mounted = await mountAndFlush(html`<${Host} />`, app);
+
+      click(indexRowsOf(mounted)[0]);
+      await flush();
+      expect(indexColumnRootOf(mounted)).toBeTruthy();
+
+      switchTable(mounted);
+      await flush();
+
+      changeCheckbox(checkboxesOf(mounted)[0], true);
+      await flush();
+
+      const { indexEntities, indexColumnEntities } =
+        app.store.state.collections;
+      expect(indexEntities['i1'].indexColumnIds).toEqual([]);
+      expect(indexColumnEntities).toEqual({});
+    });
+
+    it('drops the selection when the selected index is removed elsewhere', async () => {
+      mounted = await mountAndFlush(template(), app);
+
+      click(indexRowsOf(mounted)[0]);
+      await flush();
+      expect(indexColumnRootOf(mounted)).toBeTruthy();
+
+      // A collaborator or an undo, rather than the row's own remove button.
+      app.store.dispatchSync(removeIndexAction({ id: 'i1' }));
+      await flush();
+
+      expect(indexRowsOf(mounted)).toHaveLength(0);
+      expect(indexColumnRootOf(mounted)).toBeNull();
+      expect(checkboxesOf(mounted)[0].disabled).toBe(true);
     });
   });
 });

--- a/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.test.ts
+++ b/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.test.ts
@@ -52,6 +52,18 @@ const checkboxesOf = (mounted: Mounted) =>
 const click = (el: Element) =>
   el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
+/**
+ * Mirrors a real click: the browser flips the `checked` property before the
+ * change event, which is what sets the input's dirty checkedness flag.
+ */
+const changeCheckbox = (input: HTMLInputElement, checked: boolean) => {
+  input.checked = checked;
+  input.dispatchEvent(new InputEvent('change', { bubbles: true }));
+};
+
+const indexColumnRowsOf = (mounted: Mounted) =>
+  Array.from(indexColumnRootOf(mounted)?.children ?? []);
+
 function seed(app: AppContext) {
   const { store } = app;
   store.dispatchSync(
@@ -181,6 +193,24 @@ describe('TablePropertiesIndexes', () => {
       ).toEqual([false, true]);
     });
 
+    it('rebinds the checkbox column when the selection moves to another index', async () => {
+      mounted = await mountAndFlush(template(), app);
+
+      click(indexRowsOf(mounted)[0]);
+      await flush();
+      changeCheckbox(checkboxesOf(mounted)[0], true);
+      await flush();
+
+      expect(checkboxesOf(mounted)[0].checked).toBe(true);
+      expect(indexColumnRowsOf(mounted)).toHaveLength(1);
+
+      click(indexRowsOf(mounted)[1]);
+      await flush();
+
+      expect(checkboxesOf(mounted)[0].checked).toBe(false);
+      expect(indexColumnRowsOf(mounted)).toHaveLength(0);
+    });
+
     it('clears the selection when the selected index is removed', async () => {
       mounted = await mountAndFlush(template(), app);
 
@@ -197,6 +227,7 @@ describe('TablePropertiesIndexes', () => {
       expect(indexRowsOf(mounted)).toHaveLength(1);
       expect(indexColumnRootOf(mounted)).toBeNull();
       expect(checkboxesOf(mounted)[0].disabled).toBe(true);
+      expect(checkboxesOf(mounted)[0].checked).toBe(false);
     });
   });
 });

--- a/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.tsx
+++ b/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/TablePropertiesIndexes.tsx
@@ -23,11 +23,11 @@ const TablePropertiesIndexes: FC<TablePropertiesIndexesProps> = (
   const app = useAppContext(ctx);
 
   const state = observable({
-    index: null as Index | null,
+    indexId: null as string | null,
   });
 
   const handleSelectIndex = (index: Index | null) => {
-    state.index = index;
+    state.indexId = index?.id ?? null;
   };
 
   const handleAddIndex = () => {
@@ -48,6 +48,9 @@ const TablePropertiesIndexes: FC<TablePropertiesIndexesProps> = (
       .selectByIds(indexIds)
       .filter(index => index.tableId === tableId);
 
+    const { indexId } = state;
+    const selectedIndex = indexes.find(index => index.id === indexId) ?? null;
+
     return (
       <>
         <div class={styles.leftArea}>
@@ -57,7 +60,7 @@ const TablePropertiesIndexes: FC<TablePropertiesIndexesProps> = (
             index => (
               <IndexesIndex
                 index={index}
-                selected={index.id === state.index?.id}
+                selected={index.id === selectedIndex?.id}
                 onSelect={handleSelectIndex}
               />
             )
@@ -71,8 +74,8 @@ const TablePropertiesIndexes: FC<TablePropertiesIndexesProps> = (
           </div>
         </div>
         <div class={styles.rightArea}>
-          <IndexesCheckboxColumn tableId={tableId} index={state.index} />
-          {state.index ? <IndexesColumn index={state.index} /> : null}
+          <IndexesCheckboxColumn tableId={tableId} index={selectedIndex} />
+          {selectedIndex ? <IndexesColumn index={selectedIndex} /> : null}
         </div>
       </>
     );

--- a/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/indexes-checkbox-column/IndexesCheckboxColumn.tsx
+++ b/packages/erd-editor/src/components/erd/table-properties/table-properties-indexes/indexes-checkbox-column/IndexesCheckboxColumn.tsx
@@ -188,7 +188,7 @@ const IndexesCheckboxColumn: FC<IndexesCheckboxColumnProps> = (props, ctx) => {
                 <input
                   type="checkbox"
                   bool:disabled={!index}
-                  bool:checked={hasChecked(column.id)}
+                  prop:checked={hasChecked(column.id)}
                   on:change={event => handleChangeIndexColumn(event, column)}
                 />
               </div>


### PR DESCRIPTION
Fixes #412, and a second defect of the same shape found while verifying it.

## The reported bug

`bool:checked` compiles to `BooleanPart`, which only ever calls `setAttribute`/`removeAttribute`. A checkbox stops reflecting its `checked` attribute the moment the user clicks it, and the rows are keyed by column id so the same `<input>` survives an index switch.

Measured in Chromium, right after selecting a second index:

```
checked property  : [true, false, false]   <- "id" still painted checked
checked attribute : [null, null, null]     <- the attribute WAS removed
selected columns  : []                     <- correct, the new index is empty
```

A `checked` property-setter trap recorded **0** JS assignments on the old code (attribute flips only) and exactly one per state change after the fix, from `PropertyPart.commit`. `bool:disabled` on the same element is unaffected — `disabled` has no dirty flag.

The follow-on symptom the issue calls "interact abnormally": the stale box reads as checked, so the next click dispatched a *remove* against an index holding nothing, and the first click on a column of a newly selected index was swallowed.

The issue text reads as if the divergence appears when `+` is pressed. It does not — `+` alone leaves the panel self-consistent. It appears on the index switch that follows, which the reporter necessarily performed: the checkboxes are `bool:disabled={!index}`, so their "the three fields on the right are selectable" means an index row had been clicked.

`prop:` is what every other user-editable input in this package already uses (`TextInput`, `EditInput`, `Memo`). This checkbox was the only `bool:` binding on a user-mutable IDL attribute in the monorepo.

## The second defect

`Erd.tsx` swaps the panel's `tableId` while the panel stays mounted, so the entity held as the selection outlived its table. The left list is filtered by `tableId` and went empty, but the selection still pointed at the previous table's index — the checkbox column stayed enabled, and one click wrote the new table's column into the old table's index:

```
ON t2 : indexRows 0   disabled [false]
after click -> indexColumnEntities [{ indexId: "i1", columnId: "t2c1" }]
```

Deletes are LWW tombstones, so the same staleness survived an index removed by a collaborator or an undo. The reducers carry no matching guard: `addIndexColumn` never checks that the column and the index share a table, and `getOrCreate` would attach one to a tombstoned index — the panel is the only gate.

Fixed by keeping only the id and resolving it during render against the list actually being drawn, so the derived set is the rendered set by construction. The selection is scoped out rather than erased; returning to the table restores it.

## Verification

- 4 unit cases and 3 Playwright cases, each confirmed to fail with its fix reverted and pass with it applied. Reverting one commit's source fails exactly that commit's tests (3 and 1 respectively).
- Mutation-tested: 8 wrong implementations (resolving tombstones, dropping the `tableId` scope, leaving the children stale, over-correcting to never select) are all caught.
- `pnpm check`, `pnpm build`, `pnpm test` (3818), `e2e:typecheck`, and the full Playwright suite (52) pass, on each commit.

## Left alone, worth separate issues

- `IndexesIndex.handleRemoveIndex` calls `onSelect(null)` without checking whether it is the selected row, so removing a *different* index clears a live selection. The derivation makes the call redundant for its real purpose.
- `Erd.tsx`'s `state.tablePropertiesId` is the same shape one level up: if another replica deletes the table, "+ Add Index" stays live and stores an index pointing at a table that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
