### PR TITLE
fix: Import the table and column comments a schema SQL dump carries

### DIFF
--- a/packages/erd-editor/src/utils/schema-sql-parser/index.test.ts
+++ b/packages/erd-editor/src/utils/schema-sql-parser/index.test.ts
@@ -1,16 +1,21 @@
-import { ERDEditorSchemaV3 } from '@dineug/erd-editor-schema';
+import { ERDEditorSchemaV3, schemaV3Parser } from '@dineug/erd-editor-schema';
 import { describe, expect, it } from 'vite-plus/test';
 
 import {
   ColumnOption,
   ColumnUIKey,
+  Database,
   OrderType,
   RelationshipType,
   StartRelationshipType,
 } from '@/constants/schema';
 import { createEngineContext } from '@/engine/context';
+import { RootState } from '@/engine/state';
 import { Column, Index, Relationship, Table } from '@/internal-types';
 import { bHas } from '@/utils/bit';
+import { createTable } from '@/utils/collection/table.entity';
+import { createColumn } from '@/utils/collection/tableColumn.entity';
+import { createSchemaSQL } from '@/utils/schema-sql';
 import { schemaSQLParserToSchemaJson } from '@/utils/schema-sql-parser';
 
 type Schema = Pick<
@@ -198,6 +203,65 @@ describe('schemaSQLParserToSchemaJson', () => {
 
       expect(schema.doc.tableIds).toHaveLength(0);
       expect(schema.collections.tableColumnEntities).toEqual({});
+    });
+  });
+
+  describe('COMMENT ON merging', () => {
+    const SQL = `
+      CREATE TABLE users
+      (
+        id    INT          NOT NULL,
+        email VARCHAR(255) NOT NULL
+      );
+
+      COMMENT ON TABLE users IS 'user table';
+
+      COMMENT ON COLUMN users.id IS 'user id';
+
+      COMMENT ON COLUMN public.users.email IS 'email address';
+    `;
+
+    it('applies the PostgreSQL table and column comments', () => {
+      const schema = parse(SQL);
+      const users = tableByName(schema, 'users');
+
+      expect(users.comment).toBe('user table');
+      expect(columnByName(schema, users, 'id').comment).toBe('user id');
+      expect(columnByName(schema, users, 'email').comment).toBe(
+        'email address'
+      );
+    });
+
+    it('sizes the comment columns from the applied comments', () => {
+      const schema = parse(SQL);
+      const users = tableByName(schema, 'users');
+
+      // 'user table'.length * 10 === 100
+      expect(users.ui.widthComment).toBe(100);
+      // 'user id'.length * 10 === 70
+      expect(columnByName(schema, users, 'id').ui.widthComment).toBe(70);
+    });
+
+    it('ignores a COMMENT ON that names a table or column the source never created', () => {
+      const schema = parse(`
+        CREATE TABLE users (id INT);
+
+        COMMENT ON TABLE missing IS 'nope';
+        COMMENT ON COLUMN users.missing IS 'nope';
+        COMMENT ON COLUMN missing.id IS 'nope';
+      `);
+      const users = tableByName(schema, 'users');
+
+      expect(users.comment).toBe('');
+      expect(columnByName(schema, users, 'id').comment).toBe('');
+    });
+
+    it('reads a MySQL table option comment through the equal sign', () => {
+      const schema = parse(
+        "CREATE TABLE t (id INT) ENGINE=InnoDB COMMENT='(test)bug here!!';"
+      );
+
+      expect(tableByName(schema, 't').comment).toBe('(test)bug here!!');
     });
   });
 
@@ -592,6 +656,58 @@ describe('schemaSQLParserToSchemaJson', () => {
       expect(
         bHas(columnByName(schema, users, 'email').options, ColumnOption.unique)
       ).toBe(true);
+    });
+  });
+
+  describe('comment round trip', () => {
+    function commentedState(): RootState {
+      const state = {
+        ...schemaV3Parser({}),
+        editor: {},
+        lww: {},
+      } as unknown as RootState;
+
+      state.collections.tableColumnEntities = {
+        'col-id': createColumn({
+          id: 'col-id',
+          tableId: 'tbl-users',
+          name: 'id',
+          dataType: 'INT',
+          comment: 'user id',
+          options: ColumnOption.primaryKey | ColumnOption.notNull,
+        }),
+      };
+      state.collections.tableEntities = {
+        'tbl-users': createTable({
+          id: 'tbl-users',
+          name: 'users',
+          comment: 'user table',
+          columnIds: ['col-id'],
+        }),
+      };
+      state.doc.tableIds = ['tbl-users'];
+
+      return state;
+    }
+
+    it.each([Database.PostgreSQL, Database.Oracle, Database.MySQL])(
+      'keeps the comments of a %s export when the SQL is imported back',
+      database => {
+        const schema = parse(createSchemaSQL(commentedState(), database));
+        const users = tableByName(schema, 'users');
+
+        expect(users.comment).toBe('user table');
+        expect(columnByName(schema, users, 'id').comment).toBe('user id');
+      }
+    );
+
+    it('keeps the columns of a SQLite export, whose comments are plain -- lines', () => {
+      const schema = parse(createSchemaSQL(commentedState(), Database.SQLite));
+      const users = tableByName(schema, 'users');
+
+      expect(columnsOf(schema, users).map(column => column.name)).toEqual([
+        'id',
+      ]);
     });
   });
 });

--- a/packages/erd-editor/src/utils/schema-sql-parser/index.ts
+++ b/packages/erd-editor/src/utils/schema-sql-parser/index.ts
@@ -8,6 +8,8 @@ import {
   AlterTableAddForeignKey,
   AlterTableAddPrimaryKey,
   AlterTableAddUnique,
+  CommentOnColumn,
+  CommentOnTable,
   CreateIndex,
   CreateTable,
   schemaSQLParser,
@@ -40,6 +42,8 @@ type StatementMap = {
   primaryKeys: AlterTableAddPrimaryKey[];
   foreignKeys: AlterTableAddForeignKey[];
   uniques: AlterTableAddUnique[];
+  tableComments: CommentOnTable[];
+  columnComments: CommentOnColumn[];
 };
 
 export function schemaSQLParserToSchemaJson(
@@ -70,6 +74,8 @@ function getStatementMap(statements: Statement[]): StatementMap {
     primaryKeys: [],
     foreignKeys: [],
     uniques: [],
+    tableComments: [],
+    columnComments: [],
   };
 
   for (const statement of statements) {
@@ -105,6 +111,16 @@ function getStatementMap(statements: Statement[]): StatementMap {
           map.uniques.push(statement);
         }
         break;
+      case StatementType.commentOnTable:
+        if (statement.name) {
+          map.tableComments.push(statement);
+        }
+        break;
+      case StatementType.commentOnColumn:
+        if (statement.tableName && statement.columnName) {
+          map.columnComments.push(statement);
+        }
+        break;
     }
   }
 
@@ -117,6 +133,8 @@ function mergeTables({
   primaryKeys,
   foreignKeys,
   uniques,
+  tableComments,
+  columnComments,
 }: StatementMap): CreateTable[] {
   indexes.forEach(index => {
     const table = findByName(tables, index.tableName);
@@ -162,6 +180,25 @@ function mergeTables({
       refTableName: foreignKey.refTableName,
       refColumnNames: foreignKey.refColumnNames,
     });
+  });
+
+  // PostgreSQL and Oracle carry comments as their own statement rather than as
+  // an option on the table.
+  tableComments.forEach(({ name, comment }) => {
+    const table = findByName(tables, name);
+    if (!table) return;
+
+    table.comment = comment;
+  });
+
+  columnComments.forEach(({ tableName, columnName, comment }) => {
+    const table = findByName(tables, tableName);
+    if (!table) return;
+
+    const column = findByName(table.columns, columnName);
+    if (!column) return;
+
+    column.comment = comment;
   });
 
   return tables;

--- a/packages/schema-sql-parser/AGENTS.md
+++ b/packages/schema-sql-parser/AGENTS.md
@@ -6,9 +6,9 @@
 ## Purpose
 
 `@dineug/schema-sql-parser` is a hand-written, permissive DDL parser: `schemaSQLParser(source)` tokenizes SQL of
-any dialect and returns a flat `Statement[]` of five kinds — `create.table`, `create.index`, and
-`alter.table.add.{primaryKey,unique,foreignKey}`. Unrecognised input is skipped rather than rejected, so a real dump
-imports partially instead of failing. Its only consumer is `@dineug/erd-editor`, whose
+any dialect and returns a flat `Statement[]` of seven kinds — `create.table`, `create.index`,
+`alter.table.add.{primaryKey,unique,foreignKey}` and `comment.on.{table,column}`. Unrecognised input is skipped
+rather than rejected, so a real dump imports partially instead of failing. Its only consumer is `@dineug/erd-editor`, whose
 `src/utils/schema-sql-parser/` folds the AST into an `ERDEditorSchemaV3` document, not into editor actions.
 
 ## Key Files
@@ -19,7 +19,7 @@ imports partially instead of failing. Its only consumer is `@dineug/erd-editor`,
 | `src/parser/index.ts` | Dispatch loop — probes each matcher at `$pos`, calls a statement parser, else advances |
 | `src/parser/helper.ts` | Curried token/value predicates, the `is*` lookahead matchers, the merged `DataTypes` set |
 | `src/parser/statement/index.ts` | `Statement` union, `StatementType`, `SortType`, `RefPos`, AST node shapes |
-| `src/schema_sql_test_case.md` | 20 end-to-end fixture sections (`### ` heading + fenced `sql` + fenced `json`) |
+| `src/schema_sql_test_case.md` | 24 end-to-end fixture sections (`### ` heading + fenced `sql` + fenced `json`) |
 
 ## Subdirectories
 
@@ -52,7 +52,7 @@ imports partially instead of failing. Its only consumer is `@dineug/erd-editor`,
 ### Common Patterns
 
 - Tokenize once, then parse by lookahead — no backtracking.
-- No keyword or comment token exists: keywords are `string` tokens compared case-insensitively by value, and `"x"`, `'x'`, `` `x` `` and `[x]` all collapse to one `string` token with delimiters stripped.
+- No keyword token exists, and `--` / `/* */` comments are dropped by the lexer rather than emitted: keywords are `string` tokens compared case-insensitively by value, and `"x"`, `'x'`, `` `x` `` and `[x]` all collapse to one `string` token with delimiters stripped — but marked `quoted`, which every `is*Value` matcher refuses, so `` `key` `` is a column and `KEY` is an index.
 - Matchers are curried over `tokens` (`isCreateTable(tokens)` → `(pos) => boolean`) and hoisted out of the loop.
 - AST nodes are fully populated with `''` and `[]` rather than optional fields.
 

--- a/packages/schema-sql-parser/README.md
+++ b/packages/schema-sql-parser/README.md
@@ -5,9 +5,11 @@
 Internal to the erd-editor monorepo — this package is private and is never published to npm.
 
 `schemaSQLParser(source)` tokenizes SQL of any dialect and returns a flat array of statements:
-`create.table`, `create.index`, and `alter.table.add.{primaryKey,unique,foreignKey}`. It is permissive
+`create.table`, `create.index`, `alter.table.add.{primaryKey,unique,foreignKey}` and
+`comment.on.{table,column}`. It is permissive
 by design — anything it does not recognize is skipped instead of rejected, so a real dump full of
-dialect quirks imports partially rather than failing outright. It never throws on bad input.
+dialect quirks imports partially rather than failing outright. `--` and `/* */` comments are dropped by
+the lexer. It never throws on bad input.
 
 Its one consumer is `@dineug/erd-editor`, which depends on it as
 `"@dineug/schema-sql-parser": "workspace:*"`.
@@ -38,7 +40,10 @@ for (const statement of statements) {
 `foreignKeys`; `CreateIndex` carries `tableName`, `unique` and `columns`; the three `alter.table.add.*`
 nodes carry the altered table's `name` and `columnNames`, plus `refTableName` / `refColumnNames` on
 foreign keys — a `CONSTRAINT <id>` prefix is consumed and dropped, so the constraint's own name is not
-reported. Index columns carry a `sort` of `SortType.asc` / `SortType.desc`.
+reported. Index columns carry a `sort` of `SortType.asc` / `SortType.desc`. `CommentOnTable` carries the
+table's `name` and its `comment`, `CommentOnColumn` carries `tableName`, `columnName` and `comment` —
+PostgreSQL and Oracle attach comments with a statement of their own instead of a table option, so those
+two arrive separately from the `create.table` they belong to.
 
 ## Support DataType
 
@@ -333,6 +338,52 @@ CREATE TABLE 'users' (
   UNIQUE KEY 'users_email_unique' ('email'),
   KEY 'test_name_index' ('name'),
 );
+```
+
+### SQL Comments
+
+```sql
+-- the user table
+CREATE TABLE users /* pk: id; see docs (v2) */ (
+  id INTEGER NOT NULL, -- user id
+  /* the address it was signed up with */
+  email TEXT
+);
+```
+
+### Table Options
+
+```sql
+CREATE TABLE `role` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `key` varchar(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+  `description` text,
+  PRIMARY KEY (`id`,`key`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='role';
+```
+
+### Table COMMENT with parentheses
+
+```sql
+CREATE TABLE `test` (
+  `id` int NOT NULL COMMENT '(a)b',
+  `name` varchar(30)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='(test)bug here!!';
+```
+
+### COMMENT ON TABLE, COMMENT ON COLUMN
+
+```sql
+CREATE TABLE users (
+  id INT NOT NULL,
+  email VARCHAR(255)
+);
+
+COMMENT ON TABLE users IS 'user table';
+
+COMMENT ON COLUMN users.id IS 'user id';
+
+COMMENT ON COLUMN public.users.email IS 'email address';
 ```
 
 ### Column FOREIGN KEY

--- a/packages/schema-sql-parser/src/index.test.ts
+++ b/packages/schema-sql-parser/src/index.test.ts
@@ -70,6 +70,8 @@ describe('public entry surface', () => {
       alterTableAddUnique: 'alter.table.add.unique',
       alterTableAddPrimaryKey: 'alter.table.add.primaryKey',
       alterTableAddForeignKey: 'alter.table.add.foreignKey',
+      commentOnTable: 'comment.on.table',
+      commentOnColumn: 'comment.on.column',
     });
   });
 

--- a/packages/schema-sql-parser/src/parser/helper.test.ts
+++ b/packages/schema-sql-parser/src/parser/helper.test.ts
@@ -15,7 +15,14 @@ import {
   isAuto_incrementValue,
   isAutoIncrementValue,
   isAutoincrementValue,
+  isCharacterSet,
+  isCharacterValue,
+  isCollateValue,
+  isColumnValue,
   isCommaToken,
+  isCommentOn,
+  isCommentOnColumn,
+  isCommentOnTable,
   isCommentValue,
   isConstraintValue,
   isCreateIndex,
@@ -33,6 +40,7 @@ import {
   isForeignValue,
   isIfValue,
   isIndexValue,
+  isIsValue,
   isKeyValue,
   isLeftBracketToken,
   isLeftParentToken,
@@ -49,6 +57,7 @@ import {
   isRightParentToken,
   isSelectValue,
   isSemicolonToken,
+  isSetValue,
   isStringToken,
   isTableValue,
   isUniqueValue,
@@ -57,6 +66,11 @@ import {
 import { Token, TokenType } from '@/parser/tokenizer';
 
 const str = (value: string): Token => ({ type: TokenType.string, value });
+const quoted = (value: string): Token => ({
+  type: TokenType.string,
+  value,
+  quoted: true,
+});
 const words = (...values: string[]): Token[] => values.map(str);
 const period: Token = { type: TokenType.period, value: '.' };
 
@@ -133,6 +147,11 @@ describe('token value predicates', () => {
     ['isIfValue', isIfValue, 'IF'],
     ['isExistsValue', isExistsValue, 'EXISTS'],
     ['isOnlyValue', isOnlyValue, 'ONLY'],
+    ['isIsValue', isIsValue, 'IS'],
+    ['isColumnValue', isColumnValue, 'COLUMN'],
+    ['isCharacterValue', isCharacterValue, 'CHARACTER'],
+    ['isSetValue', isSetValue, 'SET'],
+    ['isCollateValue', isCollateValue, 'COLLATE'],
   ];
 
   it.each(cases)(
@@ -154,10 +173,90 @@ describe('token value predicates', () => {
     }
   );
 
+  it.each(cases)(
+    '%s never matches a quoted token',
+    (_name, predicate, keyword) => {
+      expect(predicate([quoted(keyword)])(0)).toBe(false);
+    }
+  );
+
   it('ignores the token type and only compares the value', () => {
     const tokens: Token[] = [{ type: TokenType.comma, value: 'create' }];
 
     expect(isCreateValue(tokens)(0)).toBe(true);
+  });
+
+  it('reads a quoted keyword as an identifier, not as the keyword', () => {
+    expect(isKeyValue([quoted('key')])(0)).toBe(false);
+    expect(isKeyValue(words('key'))(0)).toBe(true);
+  });
+});
+
+describe('isCommentOn', () => {
+  it('matches any COMMENT ON target', () => {
+    const test = isCommentOn(words('COMMENT', 'ON', 'SCHEMA'));
+
+    expect(test(0)).toBe(true);
+  });
+
+  it('rejects a MySQL table option', () => {
+    expect(isCommentOn(words('COMMENT', 'a comment'))(0)).toBe(false);
+  });
+
+  it('rejects a quoted comment value that reads ON', () => {
+    expect(isCommentOn([str('COMMENT'), quoted('ON'), str('TABLE')])(0)).toBe(
+      false
+    );
+  });
+});
+
+describe('isCommentOnTable', () => {
+  it('matches the COMMENT ON TABLE prefix', () => {
+    expect(isCommentOnTable(words('COMMENT', 'ON', 'TABLE', 'users'))(0)).toBe(
+      true
+    );
+  });
+
+  it('rejects the COMMENT ON COLUMN prefix', () => {
+    expect(isCommentOnTable(words('COMMENT', 'ON', 'COLUMN'))(0)).toBe(false);
+  });
+
+  it('rejects a MySQL table option', () => {
+    expect(isCommentOnTable(words('COMMENT', 'a comment'))(0)).toBe(false);
+  });
+
+  it('rejects a position past the end of the token list', () => {
+    expect(isCommentOnTable(words('COMMENT', 'ON'))(0)).toBe(false);
+  });
+});
+
+describe('isCommentOnColumn', () => {
+  it('matches the COMMENT ON COLUMN prefix', () => {
+    expect(
+      isCommentOnColumn(words('COMMENT', 'ON', 'COLUMN', 'users'))(0)
+    ).toBe(true);
+  });
+
+  it('rejects the COMMENT ON TABLE prefix', () => {
+    expect(isCommentOnColumn(words('COMMENT', 'ON', 'TABLE'))(0)).toBe(false);
+  });
+
+  it('rejects a position past the end of the token list', () => {
+    expect(isCommentOnColumn(words('COMMENT', 'ON'))(0)).toBe(false);
+  });
+});
+
+describe('isCharacterSet', () => {
+  it('matches the CHARACTER SET column attribute', () => {
+    expect(isCharacterSet(words('CHARACTER', 'SET', 'utf8mb3'))(0)).toBe(true);
+  });
+
+  it('rejects the CHARACTER VARYING data type', () => {
+    expect(isCharacterSet(words('CHARACTER', 'VARYING'))(0)).toBe(false);
+  });
+
+  it('rejects a position past the end of the token list', () => {
+    expect(isCharacterSet(words('CHARACTER'))(0)).toBe(false);
   });
 });
 
@@ -170,6 +269,16 @@ describe('isAutoIncrementValue', () => {
     expect(test(1)).toBe(true);
     expect(test(2)).toBe(false);
     expect(test(3)).toBe(false);
+  });
+});
+
+describe('isNewStatement - COMMENT ON', () => {
+  it('treats COMMENT ON as the start of a new statement', () => {
+    expect(isNewStatement(words('COMMENT', 'ON', 'TABLE'))(0)).toBe(true);
+  });
+
+  it('leaves a MySQL COMMENT table option alone', () => {
+    expect(isNewStatement(words('COMMENT', 'a comment'))(0)).toBe(false);
   });
 });
 

--- a/packages/schema-sql-parser/src/parser/helper.ts
+++ b/packages/schema-sql-parser/src/parser/helper.ts
@@ -9,10 +9,14 @@ import { Token, TokenType } from '@/parser/tokenizer';
 const createTypeEqual = (type: string) => (tokens: Token[]) => (pos: number) =>
   tokens[pos] ? tokens[pos].type === type : false;
 
+// A quoted token is always an identifier, never a keyword: `key` is a column
+// named key, KEY is the index definition.
 const createValueEqual = (type: string) => {
   const value = type.toUpperCase();
-  return (tokens: Token[]) => (pos: number) =>
-    tokens[pos] ? tokens[pos].value.toUpperCase() === value : false;
+  return (tokens: Token[]) => (pos: number) => {
+    const token = tokens[pos];
+    return token ? !token.quoted && token.value.toUpperCase() === value : false;
+  };
 };
 
 export const isStringToken = createTypeEqual(TokenType.string);
@@ -52,11 +56,34 @@ export const isAutoincrementValue = createValueEqual('AUTOINCREMENT');
 export const isIfValue = createValueEqual('IF');
 export const isExistsValue = createValueEqual('EXISTS');
 export const isOnlyValue = createValueEqual('ONLY');
+export const isIsValue = createValueEqual('IS');
+export const isColumnValue = createValueEqual('COLUMN');
+export const isCharacterValue = createValueEqual('CHARACTER');
+export const isSetValue = createValueEqual('SET');
+export const isCollateValue = createValueEqual('COLLATE');
 
 export const isAutoIncrementValue = (tokens: Token[]) => {
   const isAuto_increment = isAuto_incrementValue(tokens);
   const isAutoincrement = isAutoincrementValue(tokens);
   return (pos: number) => isAuto_increment(pos) || isAutoincrement(pos);
+};
+
+export const isCommentOn = (tokens: Token[]) => {
+  const isComment = isCommentValue(tokens);
+  const isOn = isOnValue(tokens);
+  return (pos: number) => isComment(pos) && isOn(pos + 1);
+};
+
+export const isCommentOnTable = (tokens: Token[]) => {
+  const commentOn = isCommentOn(tokens);
+  const isTable = isTableValue(tokens);
+  return (pos: number) => commentOn(pos) && isTable(pos + 2);
+};
+
+export const isCommentOnColumn = (tokens: Token[]) => {
+  const commentOn = isCommentOn(tokens);
+  const isColumn = isColumnValue(tokens);
+  return (pos: number) => commentOn(pos) && isColumn(pos + 2);
 };
 
 export const isNewStatement = (tokens: Token[]) => {
@@ -67,6 +94,7 @@ export const isNewStatement = (tokens: Token[]) => {
   const isRename = isRenameValue(tokens);
   const isDelete = isDeleteValue(tokens);
   const isSelect = isSelectValue(tokens);
+  const commentOn = isCommentOn(tokens);
   return (pos: number) =>
     isCreate(pos) ||
     isAlter(pos) ||
@@ -74,7 +102,8 @@ export const isNewStatement = (tokens: Token[]) => {
     isUse(pos) ||
     isRename(pos) ||
     isDelete(pos) ||
-    isSelect(pos);
+    isSelect(pos) ||
+    commentOn(pos);
 };
 
 export const isCreateTableIfNotExists = (tokens: Token[]) => {
@@ -89,6 +118,12 @@ export const isCreateTableIfNotExists = (tokens: Token[]) => {
     isIf(pos + 2) &&
     isNot(pos + 3) &&
     isExists(pos + 4);
+};
+
+export const isCharacterSet = (tokens: Token[]) => {
+  const isCharacter = isCharacterValue(tokens);
+  const isSet = isSetValue(tokens);
+  return (pos: number) => isCharacter(pos) && isSet(pos + 1);
 };
 
 export const isCreateTable = (tokens: Token[]) => {

--- a/packages/schema-sql-parser/src/parser/index.test.ts
+++ b/packages/schema-sql-parser/src/parser/index.test.ts
@@ -173,6 +173,86 @@ describe('schemaSQLParser', () => {
     ]);
   });
 
+  it('parses COMMENT ON TABLE and COMMENT ON COLUMN', () => {
+    const ast = schemaSQLParser(`
+      COMMENT ON TABLE users IS 'user table';
+      COMMENT ON COLUMN users.id IS 'user id';
+    `);
+
+    expect(ast).toEqual([
+      {
+        type: 'comment.on.table',
+        name: 'users',
+        comment: 'user table',
+      },
+      {
+        type: 'comment.on.column',
+        tableName: 'users',
+        columnName: 'id',
+        comment: 'user id',
+      },
+    ]);
+  });
+
+  it('does not read a COMMENT ON statement as the comment of the table above it', () => {
+    const ast = schemaSQLParser(`
+      CREATE TABLE users (id INT);
+
+      COMMENT ON TABLE users IS 'user table';
+
+      COMMENT ON COLUMN users.id IS 'user id';
+    `);
+
+    expect(ast.map(statement => statement.type)).toEqual([
+      'create.table',
+      'comment.on.table',
+      'comment.on.column',
+    ]);
+    expect((ast[0] as { comment: string }).comment).toBe('');
+  });
+
+  it('keeps the COMMENT ON statements of a pg_dump style source', () => {
+    const ast = schemaSQLParser(`
+      ALTER TABLE ONLY public.users
+          ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+      COMMENT ON TABLE public.users IS 'user table';
+
+      CREATE INDEX idx_users_email ON users (email);
+
+      COMMENT ON COLUMN public.users.email IS 'email address';
+
+      ALTER TABLE ONLY public.orders
+          ADD CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+      COMMENT ON COLUMN public.users.id IS 'user id';
+
+      ALTER TABLE ONLY public.users ADD CONSTRAINT uq_email UNIQUE (email);
+
+      COMMENT ON TABLE public.orders IS 'order table';
+    `);
+
+    expect(ast.map(statement => statement.type)).toEqual([
+      'alter.table.add.primaryKey',
+      'comment.on.table',
+      'create.index',
+      'comment.on.column',
+      'alter.table.add.foreignKey',
+      'comment.on.column',
+      'alter.table.add.unique',
+      'comment.on.table',
+    ]);
+  });
+
+  it('skips a COMMENT ON target it has no statement for', () => {
+    const ast = schemaSQLParser(`
+      COMMENT ON SCHEMA public IS 'standard public schema';
+      CREATE TABLE users (id INT);
+    `);
+
+    expect(ast.map(statement => statement.type)).toEqual(['create.table']);
+  });
+
   it('keeps parsing after a statement that consumes no closing semicolon', () => {
     const ast = schemaSQLParser(
       'CREATE TABLE a (id INT) CREATE TABLE b (id INT)'

--- a/packages/schema-sql-parser/src/parser/index.ts
+++ b/packages/schema-sql-parser/src/parser/index.ts
@@ -2,6 +2,8 @@ import {
   isAlterTableAddForeignKey,
   isAlterTableAddPrimaryKey,
   isAlterTableAddUnique,
+  isCommentOnColumn,
+  isCommentOnTable,
   isCreateIndex,
   isCreateTable,
 } from '@/parser/helper';
@@ -9,6 +11,8 @@ import { RefPos, Statement } from '@/parser/statement';
 import { alterTableAddForeignKeyParser } from '@/parser/statement/alter.table.add.foreignKey';
 import { alterTableAddPrimaryKeyParser } from '@/parser/statement/alter.table.add.primaryKey';
 import { alterTableAddUniqueParser } from '@/parser/statement/alter.table.add.unique';
+import { commentOnColumnParser } from '@/parser/statement/comment.on.column';
+import { commentOnTableParser } from '@/parser/statement/comment.on.table';
 import { createIndexParser } from '@/parser/statement/create.index';
 import { createTableParser } from '@/parser/statement/create.table';
 import { Token, tokenizer } from '@/parser/tokenizer';
@@ -23,6 +27,8 @@ function parser(tokens: Token[]) {
   const alterTableAddPrimaryKey = isAlterTableAddPrimaryKey(tokens);
   const alterTableAddForeignKey = isAlterTableAddForeignKey(tokens);
   const alterTableAddUnique = isAlterTableAddUnique(tokens);
+  const commentOnTable = isCommentOnTable(tokens);
+  const commentOnColumn = isCommentOnColumn(tokens);
 
   while (isToken()) {
     if (createTable($pos.value)) {
@@ -47,6 +53,16 @@ function parser(tokens: Token[]) {
 
     if (alterTableAddUnique($pos.value)) {
       ast.push(alterTableAddUniqueParser(tokens, $pos));
+      continue;
+    }
+
+    if (commentOnTable($pos.value)) {
+      ast.push(commentOnTableParser(tokens, $pos));
+      continue;
+    }
+
+    if (commentOnColumn($pos.value)) {
+      ast.push(commentOnColumnParser(tokens, $pos));
       continue;
     }
 

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.foreignKey.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.foreignKey.test.ts
@@ -26,6 +26,16 @@ const emptyAst = {
 };
 
 describe('alterTableAddForeignKeyParser', () => {
+  it('stops on the terminator instead of reading the statement after it', () => {
+    const { ast, $pos, tokens } = parse(
+      'ALTER TABLE orders ADD FOREIGN KEY (user_id) REFERENCES users (id);' +
+        " COMMENT ON TABLE orders IS 'a';"
+    );
+
+    expect(ast.name).toBe('orders');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+
   it('parses an anonymous foreign key over a single column', () => {
     const { ast } = parse(
       'ALTER TABLE post ADD FOREIGN KEY (user_id) REFERENCES user (id);'

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.foreignKey.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.foreignKey.ts
@@ -4,6 +4,7 @@ import {
   isForeignValue,
   isNewStatement,
   isPeriodToken,
+  isSemicolonToken,
   isStringToken,
   isTableValue,
 } from '@/parser/helper';
@@ -17,6 +18,7 @@ import { Token } from '@/parser/tokenizer';
 
 export function alterTableAddForeignKeyParser(tokens: Token[], $pos: RefPos) {
   const newStatement = isNewStatement(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
   const isString = isStringToken(tokens);
   const isConstraint = isConstraintValue(tokens);
   const isPeriod = isPeriodToken(tokens);
@@ -38,6 +40,13 @@ export function alterTableAddForeignKeyParser(tokens: Token[], $pos: RefPos) {
 
   while (isToken() && !newStatement($pos.value)) {
     let token = tokens[$pos.value];
+
+    // The terminator ends the statement; without it the loop runs on into
+    // whatever follows, and a `COMMENT ON` right after is swallowed.
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
 
     if (isTable($pos.value)) {
       token = tokens[++$pos.value];

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.primaryKey.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.primaryKey.test.ts
@@ -18,6 +18,15 @@ const parseTokens = (tokens: Token[], start = 0) => {
 };
 
 describe('alterTableAddPrimaryKeyParser', () => {
+  it('stops on the terminator instead of reading the statement after it', () => {
+    const { ast, $pos, tokens } = parse(
+      "ALTER TABLE users ADD PRIMARY KEY (id); COMMENT ON TABLE orders IS 'a';"
+    );
+
+    expect(ast.name).toBe('users');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+
   it('parses an anonymous primary key over a single column', () => {
     const { ast } = parse('ALTER TABLE users ADD PRIMARY KEY (id);');
 

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.primaryKey.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.primaryKey.ts
@@ -7,6 +7,7 @@ import {
   isPeriodToken,
   isPrimaryValue,
   isRightParentToken,
+  isSemicolonToken,
   isStringToken,
   isTableValue,
 } from '@/parser/helper';
@@ -19,6 +20,7 @@ import { Token } from '@/parser/tokenizer';
 
 export function alterTableAddPrimaryKeyParser(tokens: Token[], $pos: RefPos) {
   const newStatement = isNewStatement(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
   const isString = isStringToken(tokens);
   const isLeftParent = isLeftParentToken(tokens);
   const isRightParent = isRightParentToken(tokens);
@@ -41,6 +43,13 @@ export function alterTableAddPrimaryKeyParser(tokens: Token[], $pos: RefPos) {
 
   while (isToken() && !newStatement($pos.value)) {
     let token = tokens[$pos.value];
+
+    // The terminator ends the statement; without it the loop runs on into
+    // whatever follows, and a `COMMENT ON` right after is swallowed.
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
 
     if (isTable($pos.value)) {
       token = tokens[++$pos.value];

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.unique.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.unique.test.ts
@@ -18,6 +18,15 @@ const parseTokens = (tokens: Token[], start = 0) => {
 };
 
 describe('alterTableAddUniqueParser', () => {
+  it('stops on the terminator instead of reading the statement after it', () => {
+    const { ast, $pos, tokens } = parse(
+      "ALTER TABLE users ADD UNIQUE (email); COMMENT ON TABLE orders IS 'a';"
+    );
+
+    expect(ast.name).toBe('users');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+
   it('parses an anonymous unique constraint over a single column', () => {
     const { ast } = parse('ALTER TABLE users ADD UNIQUE (email);');
 

--- a/packages/schema-sql-parser/src/parser/statement/alter.table.add.unique.ts
+++ b/packages/schema-sql-parser/src/parser/statement/alter.table.add.unique.ts
@@ -5,6 +5,7 @@ import {
   isNewStatement,
   isPeriodToken,
   isRightParentToken,
+  isSemicolonToken,
   isStringToken,
   isTableValue,
   isUniqueValue,
@@ -14,6 +15,7 @@ import { Token } from '@/parser/tokenizer';
 
 export function alterTableAddUniqueParser(tokens: Token[], $pos: RefPos) {
   const newStatement = isNewStatement(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
   const isString = isStringToken(tokens);
   const isConstraint = isConstraintValue(tokens);
   const isPeriod = isPeriodToken(tokens);
@@ -35,6 +37,13 @@ export function alterTableAddUniqueParser(tokens: Token[], $pos: RefPos) {
 
   while (isToken() && !newStatement($pos.value)) {
     let token = tokens[$pos.value];
+
+    // The terminator ends the statement; without it the loop runs on into
+    // whatever follows, and a `COMMENT ON` right after is swallowed.
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
 
     if (isTable($pos.value)) {
       token = tokens[++$pos.value];

--- a/packages/schema-sql-parser/src/parser/statement/comment.on.column.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/comment.on.column.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { RefPos, StatementType } from '@/parser/statement';
+import { commentOnColumnParser } from '@/parser/statement/comment.on.column';
+import { tokenizer } from '@/parser/tokenizer';
+
+const parse = (source: string, start = 0) => {
+  const tokens = tokenizer(source);
+  const $pos: RefPos = { value: start };
+  const ast = commentOnColumnParser(tokens, $pos);
+  return { ast, $pos, tokens };
+};
+
+describe('commentOnColumnParser', () => {
+  it('splits table and column out of the qualified name', () => {
+    const { ast } = parse("COMMENT ON COLUMN users.id IS 'user id';");
+
+    expect(ast).toEqual({
+      type: StatementType.commentOnColumn,
+      tableName: 'users',
+      columnName: 'id',
+      comment: 'user id',
+    });
+  });
+
+  it('reads the last two segments of a schema qualified name', () => {
+    const { ast } = parse("COMMENT ON COLUMN public.users.id IS 'user id';");
+
+    expect(ast.tableName).toBe('users');
+    expect(ast.columnName).toBe('id');
+  });
+
+  it('unwraps quoted segments', () => {
+    const { ast } = parse(`COMMENT ON COLUMN "users"."id" IS 'user id';`);
+
+    expect(ast.tableName).toBe('users');
+    expect(ast.columnName).toBe('id');
+  });
+
+  it('keeps punctuation the comment contains', () => {
+    const { ast } = parse("COMMENT ON COLUMN users.id IS '(a, b); c';");
+
+    expect(ast.comment).toBe('(a, b); c');
+  });
+
+  it('leaves the table name empty when the column is unqualified', () => {
+    const { ast } = parse("COMMENT ON COLUMN id IS 'user id';");
+
+    expect(ast.tableName).toBe('');
+    expect(ast.columnName).toBe('id');
+  });
+
+  it('leaves every name empty when there is nothing to read', () => {
+    const { ast } = parse('COMMENT ON COLUMN;');
+
+    expect(ast).toEqual({
+      type: StatementType.commentOnColumn,
+      tableName: '',
+      columnName: '',
+      comment: '',
+    });
+  });
+
+  it('stops on the terminator', () => {
+    const { $pos, tokens } = parse(
+      "COMMENT ON COLUMN users.id IS 'user id'; CREATE TABLE t (id INT);"
+    );
+
+    expect(tokens[$pos.value].value).toBe('CREATE');
+  });
+
+  it('stops on the next statement when the terminator is missing', () => {
+    const { ast, $pos, tokens } = parse(
+      "COMMENT ON COLUMN users.id IS 'user id' CREATE TABLE t (id INT)"
+    );
+
+    expect(ast.comment).toBe('user id');
+    expect(tokens[$pos.value].value).toBe('CREATE');
+  });
+
+  it('does not read a trailing name as part of the column path', () => {
+    const { ast } = parse("COMMENT ON COLUMN users.id IS 'user id' extra");
+
+    expect(ast.tableName).toBe('users');
+    expect(ast.columnName).toBe('id');
+  });
+
+  it('reads IS NULL as no comment rather than the text NULL', () => {
+    const { ast } = parse('COMMENT ON COLUMN users.id IS NULL;');
+
+    expect(ast.comment).toBe('');
+  });
+
+  it('stops on the next COMMENT ON when no terminator separates them', () => {
+    const { ast, $pos, tokens } = parse(
+      "COMMENT ON COLUMN users.id IS 'user id'\nCOMMENT ON COLUMN users.email IS 'email'"
+    );
+
+    expect(ast.columnName).toBe('id');
+    expect(ast.comment).toBe('user id');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+});

--- a/packages/schema-sql-parser/src/parser/statement/comment.on.column.ts
+++ b/packages/schema-sql-parser/src/parser/statement/comment.on.column.ts
@@ -1,0 +1,82 @@
+import {
+  isIsValue,
+  isNewStatement,
+  isNullValue,
+  isPeriodToken,
+  isSemicolonToken,
+  isStringToken,
+} from '@/parser/helper';
+import { CommentOnColumn, RefPos, StatementType } from '@/parser/statement';
+import { Token } from '@/parser/tokenizer';
+
+// COMMENT ON COLUMN [schema.]table.column IS 'comment';
+export function commentOnColumnParser(
+  tokens: Token[],
+  $pos: RefPos
+): CommentOnColumn {
+  const newStatement = isNewStatement(tokens);
+  const isString = isStringToken(tokens);
+  const isPeriod = isPeriodToken(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
+  const isIs = isIsValue(tokens);
+  const isNull = isNullValue(tokens);
+
+  const isToken = () => $pos.value < tokens.length;
+
+  const ast: CommentOnColumn = {
+    type: StatementType.commentOnColumn,
+    tableName: '',
+    columnName: '',
+    comment: '',
+  };
+
+  $pos.value += 3;
+  const names: string[] = [];
+  let isValue = false;
+
+  while (isToken() && !newStatement($pos.value)) {
+    let token = tokens[$pos.value];
+
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
+
+    if (isIs($pos.value)) {
+      isValue = true;
+      token = tokens[++$pos.value];
+
+      // `IS NULL` removes a comment rather than setting one.
+      if (isNull($pos.value)) {
+        $pos.value++;
+        continue;
+      }
+
+      if (isString($pos.value)) {
+        ast.comment = token.value;
+        $pos.value++;
+      }
+
+      continue;
+    }
+
+    if (isPeriod($pos.value)) {
+      $pos.value++;
+      continue;
+    }
+
+    if (isString($pos.value) && !isValue) {
+      names.push(token.value);
+      $pos.value++;
+      continue;
+    }
+
+    $pos.value++;
+  }
+
+  // [schema.]table.column — the last two segments are the ones that matter.
+  ast.columnName = names.length ? names[names.length - 1] : '';
+  ast.tableName = names.length > 1 ? names[names.length - 2] : '';
+
+  return ast;
+}

--- a/packages/schema-sql-parser/src/parser/statement/comment.on.table.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/comment.on.table.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { RefPos, StatementType } from '@/parser/statement';
+import { commentOnTableParser } from '@/parser/statement/comment.on.table';
+import { tokenizer } from '@/parser/tokenizer';
+
+const parse = (source: string, start = 0) => {
+  const tokens = tokenizer(source);
+  const $pos: RefPos = { value: start };
+  const ast = commentOnTableParser(tokens, $pos);
+  return { ast, $pos, tokens };
+};
+
+describe('commentOnTableParser', () => {
+  it('parses the table name and its comment', () => {
+    const { ast } = parse("COMMENT ON TABLE users IS 'user table';");
+
+    expect(ast).toEqual({
+      type: StatementType.commentOnTable,
+      name: 'users',
+      comment: 'user table',
+    });
+  });
+
+  it('keeps the last segment of a schema qualified name', () => {
+    const { ast } = parse("COMMENT ON TABLE public.users IS 'user table';");
+
+    expect(ast.name).toBe('users');
+  });
+
+  it('unwraps a quoted table name', () => {
+    const { ast } = parse(`COMMENT ON TABLE "users" IS 'user table';`);
+
+    expect(ast.name).toBe('users');
+  });
+
+  it('keeps punctuation the comment contains', () => {
+    const { ast } = parse("COMMENT ON TABLE users IS '(a, b); c';");
+
+    expect(ast.comment).toBe('(a, b); c');
+  });
+
+  it('leaves the comment empty when IS has no value', () => {
+    const { ast } = parse('COMMENT ON TABLE users;');
+
+    expect(ast).toEqual({
+      type: StatementType.commentOnTable,
+      name: 'users',
+      comment: '',
+    });
+  });
+
+  it('stops on the terminator', () => {
+    const { $pos, tokens } = parse(
+      "COMMENT ON TABLE users IS 'user table'; CREATE TABLE t (id INT);"
+    );
+
+    expect(tokens[$pos.value].value).toBe('CREATE');
+  });
+
+  it('stops on the next statement when the terminator is missing', () => {
+    const { ast, $pos, tokens } = parse(
+      "COMMENT ON TABLE users IS 'user table' CREATE TABLE t (id INT)"
+    );
+
+    expect(ast.comment).toBe('user table');
+    expect(tokens[$pos.value].value).toBe('CREATE');
+  });
+
+  it('does not read a trailing name as the table name', () => {
+    const { ast } = parse("COMMENT ON TABLE users IS 'user table' extra");
+
+    expect(ast.name).toBe('users');
+  });
+
+  it('stops at the end of the source', () => {
+    const { ast, $pos, tokens } = parse("COMMENT ON TABLE users IS 'a'");
+
+    expect(ast.comment).toBe('a');
+    expect($pos.value).toBe(tokens.length);
+  });
+
+  it('reads IS NULL as no comment rather than the text NULL', () => {
+    const { ast } = parse('COMMENT ON TABLE users IS NULL;');
+
+    expect(ast.comment).toBe('');
+  });
+
+  it('still reads a quoted NULL as the comment', () => {
+    const { ast } = parse("COMMENT ON TABLE users IS 'NULL';");
+
+    expect(ast.comment).toBe('NULL');
+  });
+
+  it('stops on the next COMMENT ON when no terminator separates them', () => {
+    const { ast, $pos, tokens } = parse(
+      "COMMENT ON TABLE users IS 'user table'\nCOMMENT ON TABLE orders IS 'order table'"
+    );
+
+    expect(ast.comment).toBe('user table');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+});

--- a/packages/schema-sql-parser/src/parser/statement/comment.on.table.ts
+++ b/packages/schema-sql-parser/src/parser/statement/comment.on.table.ts
@@ -1,0 +1,77 @@
+import {
+  isIsValue,
+  isNewStatement,
+  isNullValue,
+  isPeriodToken,
+  isSemicolonToken,
+  isStringToken,
+} from '@/parser/helper';
+import { CommentOnTable, RefPos, StatementType } from '@/parser/statement';
+import { Token } from '@/parser/tokenizer';
+
+// COMMENT ON TABLE [schema.]name IS 'comment';
+export function commentOnTableParser(
+  tokens: Token[],
+  $pos: RefPos
+): CommentOnTable {
+  const newStatement = isNewStatement(tokens);
+  const isString = isStringToken(tokens);
+  const isPeriod = isPeriodToken(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
+  const isIs = isIsValue(tokens);
+  const isNull = isNullValue(tokens);
+
+  const isToken = () => $pos.value < tokens.length;
+
+  const ast: CommentOnTable = {
+    type: StatementType.commentOnTable,
+    name: '',
+    comment: '',
+  };
+
+  $pos.value += 3;
+  let isValue = false;
+
+  while (isToken() && !newStatement($pos.value)) {
+    let token = tokens[$pos.value];
+
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
+
+    if (isIs($pos.value)) {
+      isValue = true;
+      token = tokens[++$pos.value];
+
+      // `IS NULL` removes a comment rather than setting one.
+      if (isNull($pos.value)) {
+        $pos.value++;
+        continue;
+      }
+
+      if (isString($pos.value)) {
+        ast.comment = token.value;
+        $pos.value++;
+      }
+
+      continue;
+    }
+
+    // A qualified name keeps its last segment, the way create.table does.
+    if (isPeriod($pos.value)) {
+      $pos.value++;
+      continue;
+    }
+
+    if (isString($pos.value) && !isValue) {
+      ast.name = token.value;
+      $pos.value++;
+      continue;
+    }
+
+    $pos.value++;
+  }
+
+  return ast;
+}

--- a/packages/schema-sql-parser/src/parser/statement/create.index.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/create.index.test.ts
@@ -12,6 +12,15 @@ function parse(sql: string, start = 0) {
 }
 
 describe('createIndexParser', () => {
+  it('stops on the terminator instead of reading the statement after it', () => {
+    const { ast, $pos, tokens } = parse(
+      "CREATE INDEX idx_a ON t (a); COMMENT ON TABLE t IS 'a';"
+    );
+
+    expect(ast.tableName).toBe('t');
+    expect(tokens[$pos.value].value).toBe('COMMENT');
+  });
+
   it('parses a simple non unique index', () => {
     const { ast } = parse('CREATE INDEX idx_a ON t (a);');
 

--- a/packages/schema-sql-parser/src/parser/statement/create.index.ts
+++ b/packages/schema-sql-parser/src/parser/statement/create.index.ts
@@ -8,6 +8,7 @@ import {
   isNewStatement,
   isOnValue,
   isRightParentToken,
+  isSemicolonToken,
   isStringToken,
   isUniqueValue,
 } from '@/parser/helper';
@@ -22,6 +23,7 @@ import { Token } from '@/parser/tokenizer';
 
 export function createIndexParser(tokens: Token[], $pos: RefPos) {
   const newStatement = isNewStatement(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
   const isUnique = isUniqueValue(tokens);
   const isString = isStringToken(tokens);
   const isLeftParent = isLeftParentToken(tokens);
@@ -47,6 +49,13 @@ export function createIndexParser(tokens: Token[], $pos: RefPos) {
 
   while (isToken() && !newStatement($pos.value)) {
     let token = tokens[$pos.value];
+
+    // The terminator ends the statement; without it the loop runs on into
+    // whatever follows, and a `COMMENT ON` right after is swallowed.
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
 
     if (isIndex($pos.value)) {
       token = tokens[++$pos.value];

--- a/packages/schema-sql-parser/src/parser/statement/create.table.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/create.table.test.ts
@@ -111,8 +111,25 @@ describe('createTableParser - table name', () => {
     expect(ast.columns).toEqual([column({ name: 'a', dataType: 'INT' })]);
   });
 
-  it('ignores a table COMMENT that is written with an equal sign', () => {
+  it('reads a table COMMENT that is written with an equal sign', () => {
     const { ast } = parse("CREATE TABLE t (id INT) COMMENT='table comment';");
+
+    expect(ast.comment).toBe('table comment');
+  });
+
+  it('keeps parentheses that a quoted table COMMENT contains', () => {
+    const { ast } = parse(
+      "CREATE TABLE t (id INT) ENGINE=InnoDB COMMENT='(test)bug here!!';"
+    );
+
+    expect(ast.comment).toBe('(test)bug here!!');
+    expect(ast.columns).toEqual([column({ name: 'id', dataType: 'INT' })]);
+  });
+
+  it('stops at the terminator instead of reading the next statement as options', () => {
+    const { ast } = parse(
+      "CREATE TABLE t (id INT);\nCOMMENT ON TABLE t IS 'table comment';"
+    );
 
     expect(ast.comment).toBe('');
   });
@@ -248,6 +265,74 @@ describe('createTableParser - column options', () => {
     expect(ast.columns).toEqual([
       column({ name: 'id', dataType: 'serial', primaryKey: true }),
       column({ name: 'd', dataType: 'time' }),
+    ]);
+  });
+});
+
+describe('createTableParser - column attributes', () => {
+  it('reads a quoted reserved word as a column name', () => {
+    const { ast } = parse('CREATE TABLE `t` (`key` VARCHAR(30) NOT NULL);');
+
+    expect(ast.columns).toEqual([
+      column({ name: 'key', dataType: 'VARCHAR(30)', nullable: false }),
+    ]);
+    expect(ast.indexes).toEqual([]);
+  });
+
+  it('still reads an unquoted KEY as an index definition', () => {
+    const { ast } = parse('CREATE TABLE t (a INT, KEY idx_a (a));');
+
+    expect(ast.columns).toEqual([column({ name: 'a', dataType: 'INT' })]);
+    expect(ast.indexes).toEqual([
+      { name: 'idx_a', unique: false, columns: [{ name: 'a', sort: 'ASC' }] },
+    ]);
+  });
+
+  it('skips CHARACTER SET and COLLATE instead of reading them as the data type', () => {
+    const { ast } = parse(
+      'CREATE TABLE t (a VARCHAR(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL);'
+    );
+
+    expect(ast.columns).toEqual([
+      column({ name: 'a', dataType: 'VARCHAR(30)', nullable: false }),
+    ]);
+  });
+
+  it('skips a COLLATE written with an equal sign', () => {
+    const { ast } = parse('CREATE TABLE t (a VARCHAR(30) COLLATE=binary);');
+
+    expect(ast.columns).toEqual([
+      column({ name: 'a', dataType: 'VARCHAR(30)' }),
+    ]);
+  });
+
+  it('keeps the column list when a comment before it holds a semicolon or parentheses', () => {
+    const { ast } = parse(
+      'CREATE TABLE users /* pk: id; see docs (v2) */ (id INT, name VARCHAR(30));'
+    );
+
+    expect(ast.columns).toEqual([
+      column({ name: 'id', dataType: 'INT' }),
+      column({ name: 'name', dataType: 'VARCHAR(30)' }),
+    ]);
+  });
+
+  it('keeps the column list when a table option brings a second paren group', () => {
+    const { ast } = parse(
+      'CREATE TABLE t (id INT, name VARCHAR(30)) WITH (fillfactor=70);'
+    );
+
+    expect(ast.columns).toEqual([
+      column({ name: 'id', dataType: 'INT' }),
+      column({ name: 'name', dataType: 'VARCHAR(30)' }),
+    ]);
+  });
+
+  it('reads a column COMMENT written with an equal sign', () => {
+    const { ast } = parse("CREATE TABLE t (a INT COMMENT='(a)b');");
+
+    expect(ast.columns).toEqual([
+      column({ name: 'a', dataType: 'INT', comment: '(a)b' }),
     ]);
   });
 });

--- a/packages/schema-sql-parser/src/parser/statement/create.table.ts
+++ b/packages/schema-sql-parser/src/parser/statement/create.table.ts
@@ -1,6 +1,8 @@
 import {
   isAscValue,
   isAutoIncrementValue,
+  isCharacterSet,
+  isCollateValue,
   isCommaToken,
   isCommentValue,
   isConstraintValue,
@@ -8,6 +10,7 @@ import {
   isDataType,
   isDefaultValue,
   isDescValue,
+  isEqualToken,
   isForeignValue,
   isIndexValue,
   isKeyValue,
@@ -19,6 +22,7 @@ import {
   isPrimaryValue,
   isReferencesValue,
   isRightParentToken,
+  isSemicolonToken,
   isStringToken,
   isUniqueValue,
 } from '@/parser/helper';
@@ -39,7 +43,10 @@ export function createTableParser(tokens: Token[], $pos: RefPos) {
   const newStatement = isNewStatement(tokens);
   const isString = isStringToken(tokens);
   const isLeftParent = isLeftParentToken(tokens);
+  const isRightParent = isRightParentToken(tokens);
   const isPeriod = isPeriodToken(tokens);
+  const isSemicolon = isSemicolonToken(tokens);
+  const isEqual = isEqualToken(tokens);
   const isComment = isCommentValue(tokens);
   const createTableIfNotExists = isCreateTableIfNotExists(tokens);
 
@@ -55,12 +62,40 @@ export function createTableParser(tokens: Token[], $pos: RefPos) {
   };
 
   $pos.value += createTableIfNotExists($pos.value) ? 5 : 2;
+  let hasColumns = false;
 
   while (isToken() && !newStatement($pos.value)) {
     let token = tokens[$pos.value];
 
+    // The terminator ends the statement: without it the table options loop
+    // runs on into whatever follows, and a `COMMENT ON TABLE` right after
+    // reads back as the table comment `ON`.
+    if (isSemicolon($pos.value)) {
+      $pos.value++;
+      break;
+    }
+
     if (isLeftParent($pos.value)) {
       $pos.value++;
+
+      // Only the first group is the column list. A later one — `WITH (...)`,
+      // or a paren the tokenizer found outside a quote — would otherwise
+      // replace everything the table already has.
+      if (hasColumns) {
+        let depth = 1;
+
+        while (isToken() && depth > 0) {
+          if (isLeftParent($pos.value)) {
+            depth++;
+          } else if (isRightParent($pos.value)) {
+            depth--;
+          }
+          $pos.value++;
+        }
+
+        continue;
+      }
+
       const { columns, indexes, foreignKeys } = createTableColumnsParser(
         tokens,
         $pos
@@ -68,6 +103,7 @@ export function createTableParser(tokens: Token[], $pos: RefPos) {
       ast.columns = columns;
       ast.indexes = indexes;
       ast.foreignKeys = foreignKeys;
+      hasColumns = true;
       continue;
     }
 
@@ -90,6 +126,11 @@ export function createTableParser(tokens: Token[], $pos: RefPos) {
 
     if (isComment($pos.value)) {
       token = tokens[++$pos.value];
+
+      // MySQL writes the table option as `COMMENT='a'`.
+      if (isEqual($pos.value)) {
+        token = tokens[++$pos.value];
+      }
 
       if (isString($pos.value)) {
         ast.comment = token.value;
@@ -126,6 +167,9 @@ function createTableColumnsParser(
   const isDesc = isDescValue(tokens);
   const isAsc = isAscValue(tokens);
   const isKey = isKeyValue(tokens);
+  const isEqual = isEqualToken(tokens);
+  const characterSet = isCharacterSet(tokens);
+  const isCollate = isCollateValue(tokens);
   const dataType = isDataType(tokens);
 
   const isToken = () => $pos.value < tokens.length;
@@ -330,6 +374,10 @@ function createTableColumnsParser(
     if (isComment($pos.value)) {
       token = tokens[++$pos.value];
 
+      if (isEqual($pos.value)) {
+        token = tokens[++$pos.value];
+      }
+
       if (isString($pos.value)) {
         column.comment = token.value;
         $pos.value++;
@@ -341,6 +389,33 @@ function createTableColumnsParser(
     if (isAutoIncrement($pos.value)) {
       column.autoIncrement = true;
       $pos.value++;
+      continue;
+    }
+
+    // `CHARACTER SET x` and `COLLATE y` are column attributes, but CHARACTER,
+    // SET and some collation names are data types — left alone they overwrite
+    // the one already parsed.
+    if (characterSet($pos.value)) {
+      $pos.value += 2;
+
+      if (isString($pos.value)) {
+        $pos.value++;
+      }
+
+      continue;
+    }
+
+    if (isCollate($pos.value)) {
+      $pos.value++;
+
+      if (isEqual($pos.value)) {
+        $pos.value++;
+      }
+
+      if (isString($pos.value)) {
+        $pos.value++;
+      }
+
       continue;
     }
 

--- a/packages/schema-sql-parser/src/parser/statement/index.test.ts
+++ b/packages/schema-sql-parser/src/parser/statement/index.test.ts
@@ -11,14 +11,16 @@ describe('StatementType', () => {
       alterTableAddUnique: 'alter.table.add.unique',
       alterTableAddPrimaryKey: 'alter.table.add.primaryKey',
       alterTableAddForeignKey: 'alter.table.add.foreignKey',
+      commentOnTable: 'comment.on.table',
+      commentOnColumn: 'comment.on.column',
     });
   });
 
-  it('exposes exactly five distinct discriminators', () => {
+  it('exposes exactly seven distinct discriminators', () => {
     const values = Object.values(StatementType);
 
-    expect(values).toHaveLength(5);
-    expect(new Set(values).size).toBe(5);
+    expect(values).toHaveLength(7);
+    expect(new Set(values).size).toBe(7);
   });
 
   it('names alter statements after their ALTER TABLE ADD prefix', () => {

--- a/packages/schema-sql-parser/src/parser/statement/index.ts
+++ b/packages/schema-sql-parser/src/parser/statement/index.ts
@@ -5,7 +5,9 @@ export type Statement =
   | CreateIndex
   | AlterTableAddUnique
   | AlterTableAddPrimaryKey
-  | AlterTableAddForeignKey;
+  | AlterTableAddForeignKey
+  | CommentOnTable
+  | CommentOnColumn;
 
 export const StatementType = {
   createTable: 'create.table',
@@ -13,6 +15,8 @@ export const StatementType = {
   alterTableAddUnique: 'alter.table.add.unique',
   alterTableAddPrimaryKey: 'alter.table.add.primaryKey',
   alterTableAddForeignKey: 'alter.table.add.foreignKey',
+  commentOnTable: 'comment.on.table',
+  commentOnColumn: 'comment.on.column',
 } as const;
 export type StatementType = ValuesType<typeof StatementType>;
 
@@ -93,4 +97,17 @@ export type AlterTableAddForeignKey = {
   columnNames: string[];
   refTableName: string;
   refColumnNames: string[];
+};
+
+export type CommentOnTable = {
+  type: typeof StatementType.commentOnTable;
+  name: string;
+  comment: string;
+};
+
+export type CommentOnColumn = {
+  type: typeof StatementType.commentOnColumn;
+  tableName: string;
+  columnName: string;
+  comment: string;
 };

--- a/packages/schema-sql-parser/src/parser/tokenizer.test.ts
+++ b/packages/schema-sql-parser/src/parser/tokenizer.test.ts
@@ -22,6 +22,18 @@ describe('TokenType', () => {
 });
 
 describe('tokenizer', () => {
+  describe('quoted flag', () => {
+    it('marks every quoting style as quoted', () => {
+      expect(tokenizer('`a` "b" \'c\' [d]').map(token => token.quoted)).toEqual(
+        [true, true, true, true]
+      );
+    });
+
+    it('leaves a bare word unquoted', () => {
+      expect(tokenizer('a').map(token => token.quoted)).toEqual([undefined]);
+    });
+  });
+
   describe('empty and whitespace input', () => {
     it('returns no tokens for an empty source', () => {
       expect(tokenizer('')).toEqual([]);
@@ -83,23 +95,25 @@ describe('tokenizer', () => {
   describe('bracket quoting', () => {
     it('reads a bracket quoted identifier as a single string token', () => {
       expect(tokenizer('[my table]')).toEqual([
-        { type: TokenType.string, value: 'my table' },
+        { type: TokenType.string, value: 'my table', quoted: true },
       ]);
     });
 
     it('keeps break characters inside brackets', () => {
       expect(tokenizer('[a.b,c(d)]')).toEqual([
-        { type: TokenType.string, value: 'a.b,c(d)' },
+        { type: TokenType.string, value: 'a.b,c(d)', quoted: true },
       ]);
     });
 
     it('produces an empty string token for an empty bracket pair', () => {
-      expect(tokenizer('[]')).toEqual([{ type: TokenType.string, value: '' }]);
+      expect(tokenizer('[]')).toEqual([
+        { type: TokenType.string, value: '', quoted: true },
+      ]);
     });
 
     it('consumes the rest of the source when the bracket is unterminated', () => {
       expect(tokenizer('[abc')).toEqual([
-        { type: TokenType.string, value: 'abc' },
+        { type: TokenType.string, value: 'abc', quoted: true },
       ]);
     });
 
@@ -115,23 +129,25 @@ describe('tokenizer', () => {
   describe('double quote quoting', () => {
     it('reads a double quoted identifier as a single string token', () => {
       expect(tokenizer('"my table"')).toEqual([
-        { type: TokenType.string, value: 'my table' },
+        { type: TokenType.string, value: 'my table', quoted: true },
       ]);
     });
 
     it('keeps break characters inside double quotes', () => {
       expect(tokenizer('"a.b;c"')).toEqual([
-        { type: TokenType.string, value: 'a.b;c' },
+        { type: TokenType.string, value: 'a.b;c', quoted: true },
       ]);
     });
 
     it('produces an empty string token for an empty double quote pair', () => {
-      expect(tokenizer('""')).toEqual([{ type: TokenType.string, value: '' }]);
+      expect(tokenizer('""')).toEqual([
+        { type: TokenType.string, value: '', quoted: true },
+      ]);
     });
 
     it('consumes the rest of the source when the double quote is unterminated', () => {
       expect(tokenizer('"abc')).toEqual([
-        { type: TokenType.string, value: 'abc' },
+        { type: TokenType.string, value: 'abc', quoted: true },
       ]);
     });
   });
@@ -139,23 +155,25 @@ describe('tokenizer', () => {
   describe('single quote quoting', () => {
     it('reads a single quoted literal as a single string token', () => {
       expect(tokenizer("'hello world'")).toEqual([
-        { type: TokenType.string, value: 'hello world' },
+        { type: TokenType.string, value: 'hello world', quoted: true },
       ]);
     });
 
     it('keeps break characters inside single quotes', () => {
       expect(tokenizer("'(1,2)'")).toEqual([
-        { type: TokenType.string, value: '(1,2)' },
+        { type: TokenType.string, value: '(1,2)', quoted: true },
       ]);
     });
 
     it('produces an empty string token for an empty single quote pair', () => {
-      expect(tokenizer("''")).toEqual([{ type: TokenType.string, value: '' }]);
+      expect(tokenizer("''")).toEqual([
+        { type: TokenType.string, value: '', quoted: true },
+      ]);
     });
 
     it('consumes the rest of the source when the single quote is unterminated', () => {
       expect(tokenizer("'abc")).toEqual([
-        { type: TokenType.string, value: 'abc' },
+        { type: TokenType.string, value: 'abc', quoted: true },
       ]);
     });
   });
@@ -163,24 +181,81 @@ describe('tokenizer', () => {
   describe('backtick quoting', () => {
     it('reads a backtick quoted identifier as a single string token', () => {
       expect(tokenizer('`my table`')).toEqual([
-        { type: TokenType.string, value: 'my table' },
+        { type: TokenType.string, value: 'my table', quoted: true },
       ]);
     });
 
     it('keeps break characters inside backticks', () => {
       expect(tokenizer('`a.b`')).toEqual([
-        { type: TokenType.string, value: 'a.b' },
+        { type: TokenType.string, value: 'a.b', quoted: true },
       ]);
     });
 
     it('produces an empty string token for an empty backtick pair', () => {
-      expect(tokenizer('``')).toEqual([{ type: TokenType.string, value: '' }]);
+      expect(tokenizer('``')).toEqual([
+        { type: TokenType.string, value: '', quoted: true },
+      ]);
     });
 
     it('consumes the rest of the source when the backtick is unterminated', () => {
       expect(tokenizer('`abc')).toEqual([
-        { type: TokenType.string, value: 'abc' },
+        { type: TokenType.string, value: 'abc', quoted: true },
       ]);
+    });
+  });
+
+  describe('sql comments', () => {
+    it('drops a line comment and everything it contains', () => {
+      expect(pairs(tokenizer('a -- b; c (d)\ne'))).toEqual([
+        ['string', 'a'],
+        ['string', 'e'],
+      ]);
+    });
+
+    it('drops a line comment that runs to the end of the source', () => {
+      expect(pairs(tokenizer('a -- b'))).toEqual([['string', 'a']]);
+    });
+
+    it('ends a bare word at a line comment that has no space in front of it', () => {
+      expect(pairs(tokenizer('INT-- pk\nb'))).toEqual([
+        ['string', 'INT'],
+        ['string', 'b'],
+      ]);
+    });
+
+    it('drops a block comment and everything it contains', () => {
+      expect(pairs(tokenizer('a /* b; c (d) */ e'))).toEqual([
+        ['string', 'a'],
+        ['string', 'e'],
+      ]);
+    });
+
+    it('drops a block comment spread over several lines', () => {
+      expect(pairs(tokenizer('a /*\n b;\n*/ e'))).toEqual([
+        ['string', 'a'],
+        ['string', 'e'],
+      ]);
+    });
+
+    it('ends a bare word at a block comment that has no space in front of it', () => {
+      expect(pairs(tokenizer('INT/* pk */b'))).toEqual([
+        ['string', 'INT'],
+        ['string', 'b'],
+      ]);
+    });
+
+    it('consumes the rest of the source when the block comment is unterminated', () => {
+      expect(pairs(tokenizer('a /* b'))).toEqual([['string', 'a']]);
+    });
+
+    it('keeps comment markers that sit inside a quoted value', () => {
+      expect(pairs(tokenizer("'a -- b /* c */'"))).toEqual([
+        ['string', 'a -- b /* c */'],
+      ]);
+    });
+
+    it('does not read a single dash as a comment', () => {
+      expect(pairs(tokenizer('-1'))).toEqual([['string', '-1']]);
     });
   });
 
@@ -209,16 +284,16 @@ describe('tokenizer', () => {
       ]);
     });
 
-    it('does not break a bare word on an equal sign', () => {
-      expect(pairs(tokenizer('a=b'))).toEqual([['string', 'a=b']]);
-    });
-
-    it('emits an equal token only when it starts a token', () => {
-      expect(pairs(tokenizer('a = b'))).toEqual([
+    it('breaks a bare word on an equal sign', () => {
+      expect(pairs(tokenizer('a=b'))).toEqual([
         ['string', 'a'],
         ['equal', '='],
         ['string', 'b'],
       ]);
+    });
+
+    it('emits the same tokens whether or not the equal sign is padded', () => {
+      expect(pairs(tokenizer('a = b'))).toEqual(pairs(tokenizer('a=b')));
     });
 
     it('stops a bare word at the end of the source', () => {
@@ -227,6 +302,26 @@ describe('tokenizer', () => {
 
     it('treats a quote in the middle of a bare word as part of the word', () => {
       expect(pairs(tokenizer("a'b'"))).toEqual([['string', "a'b'"]]);
+    });
+
+    it('keeps a typed literal prefix attached to its literal', () => {
+      expect(pairs(tokenizer("N'hello'"))).toEqual([['string', "N'hello'"]]);
+    });
+
+    it('splits a MySQL table option written without whitespace', () => {
+      expect(pairs(tokenizer("COMMENT='role'"))).toEqual([
+        ['string', 'COMMENT'],
+        ['equal', '='],
+        ['string', 'role'],
+      ]);
+    });
+
+    it('keeps parentheses inside a quoted option value out of the token stream', () => {
+      expect(pairs(tokenizer("COMMENT='(test)bug here!!'"))).toEqual([
+        ['string', 'COMMENT'],
+        ['equal', '='],
+        ['string', '(test)bug here!!'],
+      ]);
     });
   });
 

--- a/packages/schema-sql-parser/src/parser/tokenizer.ts
+++ b/packages/schema-sql-parser/src/parser/tokenizer.ts
@@ -3,6 +3,9 @@ import { ValuesType } from '@/internal-types';
 export type Token = {
   type: TokenType;
   value: string;
+  // Set on tokens that came out of `"`, `'`, backtick or `[]` quoting, so a
+  // quoted identifier such as `key` is never read back as the KEY keyword.
+  quoted?: boolean;
 };
 
 export const TokenType = {
@@ -20,11 +23,15 @@ export type TokenType = ValuesType<typeof TokenType>;
 
 const pattern = {
   doubleQuote: `"`,
+  dash: '-',
+  slash: '/',
+  asterisk: '*',
+  newLine: '\n',
   singleQuote: `'`,
   backtick: '`',
   whiteSpace: /\s/,
   string: /\S/,
-  breakString: /;|,|\(|\)|\[|\]|\./,
+  breakString: /;|,|\(|\)|\[|\]|\.|=/,
   equal: '=',
   period: '.',
   comma: ',',
@@ -40,6 +47,10 @@ const createTest = (regexp: RegExp) => (char: string) => regexp.test(char);
 
 const match = {
   doubleQuote: createEqual(pattern.doubleQuote),
+  dash: createEqual(pattern.dash),
+  slash: createEqual(pattern.slash),
+  asterisk: createEqual(pattern.asterisk),
+  newLine: createEqual(pattern.newLine),
   singleQuote: createEqual(pattern.singleQuote),
   backtick: createEqual(pattern.backtick),
   whiteSpace: createTest(pattern.whiteSpace),
@@ -71,6 +82,30 @@ export function tokenizer(source: string): Token[] {
         value += char;
         char = source[++pos];
       }
+      continue;
+    }
+
+    // SQL comments are not tokens: a `;` or `(` inside one would otherwise end
+    // the statement or be read as its column list.
+    if (match.dash(char) && match.dash(source[pos + 1])) {
+      while (isChar() && !match.newLine(char)) {
+        char = source[++pos];
+      }
+      continue;
+    }
+
+    if (match.slash(char) && match.asterisk(source[pos + 1])) {
+      pos += 2;
+      char = source[pos];
+
+      while (
+        isChar() &&
+        !(match.asterisk(char) && match.slash(source[pos + 1]))
+      ) {
+        char = source[++pos];
+      }
+
+      pos += 2;
       continue;
     }
 
@@ -119,7 +154,7 @@ export function tokenizer(source: string): Token[] {
         char = source[++pos];
       }
 
-      tokens.push({ type: TokenType.string, value });
+      tokens.push({ type: TokenType.string, value, quoted: true });
       pos++;
       continue;
     }
@@ -133,7 +168,7 @@ export function tokenizer(source: string): Token[] {
         char = source[++pos];
       }
 
-      tokens.push({ type: TokenType.string, value });
+      tokens.push({ type: TokenType.string, value, quoted: true });
       pos++;
       continue;
     }
@@ -147,7 +182,7 @@ export function tokenizer(source: string): Token[] {
         char = source[++pos];
       }
 
-      tokens.push({ type: TokenType.string, value });
+      tokens.push({ type: TokenType.string, value, quoted: true });
       pos++;
       continue;
     }
@@ -161,7 +196,7 @@ export function tokenizer(source: string): Token[] {
         char = source[++pos];
       }
 
-      tokens.push({ type: TokenType.string, value });
+      tokens.push({ type: TokenType.string, value, quoted: true });
       pos++;
       continue;
     }
@@ -169,7 +204,14 @@ export function tokenizer(source: string): Token[] {
     if (match.string(char)) {
       let value = '';
 
-      while (isChar() && match.string(char) && !match.breakString(char)) {
+      while (
+        isChar() &&
+        match.string(char) &&
+        !match.breakString(char) &&
+        // A comment needs no whitespace in front of it: `INT-- pk`.
+        !(match.dash(char) && match.dash(source[pos + 1])) &&
+        !(match.slash(char) && match.asterisk(source[pos + 1]))
+      ) {
         value += char;
         char = source[++pos];
       }

--- a/packages/schema-sql-parser/src/schema_sql_test_case.md
+++ b/packages/schema-sql-parser/src/schema_sql_test_case.md
@@ -1088,3 +1088,219 @@ ALTER TABLE ONLY "public".Persons ADD CONSTRAINT UC_Person UNIQUE (ID,LastName)
   ]
 }
 ```
+### Table Options
+
+```sql
+CREATE TABLE `role` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `key` varchar(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+  `description` text,
+  PRIMARY KEY (`id`,`key`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='role';
+```
+
+```json
+{
+  "statements": [
+    {
+      "type": "create.table",
+      "name": "role",
+      "comment": "role",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "int",
+          "default": "",
+          "comment": "",
+          "primaryKey": true,
+          "autoIncrement": true,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "key",
+          "dataType": "varchar(30)",
+          "default": "",
+          "comment": "",
+          "primaryKey": true,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "dataType": "text",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": true
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    }
+  ]
+}
+```
+
+### Table COMMENT with parentheses
+
+```sql
+CREATE TABLE `test` (
+  `id` int NOT NULL COMMENT '(a)b',
+  `name` varchar(30)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='(test)bug here!!';
+```
+
+```json
+{
+  "statements": [
+    {
+      "type": "create.table",
+      "name": "test",
+      "comment": "(test)bug here!!",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "int",
+          "default": "",
+          "comment": "(a)b",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "dataType": "varchar(30)",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": true
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    }
+  ]
+}
+```
+
+### COMMENT ON TABLE, COMMENT ON COLUMN
+
+```sql
+CREATE TABLE users (
+  id INT NOT NULL,
+  email VARCHAR(255)
+);
+
+COMMENT ON TABLE users IS 'user table';
+
+COMMENT ON COLUMN users.id IS 'user id';
+
+COMMENT ON COLUMN public.users.email IS 'email address';
+```
+
+```json
+{
+  "statements": [
+    {
+      "type": "create.table",
+      "name": "users",
+      "comment": "",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "INT",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "dataType": "VARCHAR(255)",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": true
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    },
+    {
+      "type": "comment.on.table",
+      "name": "users",
+      "comment": "user table"
+    },
+    {
+      "type": "comment.on.column",
+      "tableName": "users",
+      "columnName": "id",
+      "comment": "user id"
+    },
+    {
+      "type": "comment.on.column",
+      "tableName": "users",
+      "columnName": "email",
+      "comment": "email address"
+    }
+  ]
+}
+```
+
+### SQL Comments
+
+```sql
+-- the user table
+CREATE TABLE users /* pk: id; see docs (v2) */ (
+  id INTEGER NOT NULL, -- user id
+  /* the address it was signed up with */
+  email TEXT
+);
+```
+
+```json
+{
+  "statements": [
+    {
+      "type": "create.table",
+      "name": "users",
+      "comment": "",
+      "columns": [
+        {
+          "name": "id",
+          "dataType": "INTEGER",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "dataType": "TEXT",
+          "default": "",
+          "comment": "",
+          "primaryKey": false,
+          "autoIncrement": false,
+          "unique": false,
+          "nullable": true
+        }
+      ],
+      "indexes": [],
+      "foreignKeys": []
+    }
+  ]
+}
+```


### PR DESCRIPTION
Fixes #367, #379 and #395. All three are the same thing seen from three dialects — a comment that never reaches the editor — and reproducing them turned up four more defects in the same paths.

## The three reports

### #379 — `COMMENT='role'` is dropped, and so is the `key` column

The lexer breaks a bare word on `;,()[].` but not on `=`, so `COMMENT='role'` was one token and never matched the COMMENT keyword. `COMMENT = 'role'` does emit an equal token, but `createTableParser` refused to step over it — which is why `data/sakila.sql`, checked in here all along, has been importing its `customer` table with that comment silently dropped.

The reporter's dump lost more than the title. On `main` it parses to:

```
columns: id:int, CHARACTER:SET, description:text     <- `key` gone, phantom column
indexes: varchar (column "30")                       <- phantom index
comment: ""
```

Two causes. A backtick-quoted `` `key` `` was compared against the KEY keyword, so the column was read as an index definition and its `varchar(30)` became that index's name. And `CHARACTER SET utf8mb3` is a column attribute whose two words are both data types, so it overwrote the type already parsed.

A quoted token is now always an identifier, never a keyword — one change in `createValueEqual` that covers `` `key` ``, `"default"`, `[comment]` and every other quoted reserved word. `CHARACTER SET x` and `COLLATE y` are consumed as attributes. The dump now parses to `id`, `key`, `description`, both primary-key columns marked, no phantom index, comment `role`.

### #395 — parentheses inside a comment destroy the table

`COMMENT='(test)bug here!!'` ended its token at the `(`. That stray parenthesis then re-entered the column parser, which **replaced** the table's already-parsed columns with whatever the comment text happened to contain. The `=` fix removes the split; `createTableParser` also no longer lets a second paren group replace a column list, so `WITH (fillfactor=70)` and anything else after the column list is inert.

### #367 — PostgreSQL comments import as the literal text `ON`

`COMMENT ON TABLE t IS 'c'` and `COMMENT ON COLUMN t.c IS 'x'` are how PostgreSQL and Oracle attach comments, and no statement existed for them. Worse, `createTableParser` never stopped at its terminator, so it walked into the `COMMENT ON TABLE` that this editor's own exporter writes directly after the `CREATE TABLE` and read `ON` back as the table comment. That is the "static ON comment" in the report.

Two new statement kinds — `comment.on.table` and `comment.on.column` — carry the result, and `packages/erd-editor` merges them onto the tables before those become entities, so the comment sizes its own column width. `IS NULL` clears a comment rather than storing the text `NULL`.

Every statement parser now stops at `;`, and `COMMENT ON` is a statement boundary in its own right. Both matter for real dumps: `pg_dump` writes `ALTER TABLE ONLY … ADD CONSTRAINT …;` before its comments, and on `main` that ALTER swallowed the two `COMMENT ON` statements after it and corrupted the next `CREATE INDEX` into `tableName: "TABLE"`.

## The lexer now drops `--` and `/* */`

It never did. Without it the new terminator stop is a regression: a `;` inside a comment ahead of the column list ends the statement early, and a `(` inside one is taken for the column list. A commented-out `-- COMMENT ON TABLE users IS 'old';` was also obeyed and overwrote the real comment.

This is also why importing this editor's own SQLite export produced a table whose every column was named `--`.

## Verification

- `pnpm check`, `pnpm test` (6685 tests over 9 packages) and `pnpm build` pass **on each commit**. The parser suite goes from 416 to 533 tests; three end-to-end fixtures in `schema_sql_test_case.md` are the three issues' own SQL, plus one for comment handling.
- Export → import round trips for PostgreSQL, Oracle and MySQL are asserted in `packages/erd-editor`, since a round trip is what #367 actually reported. SQLite's columns are asserted too — its comments are plain `--` lines that no importer can read back.
- **Regression measured, not assumed.** Both parser bundles — this branch and `main` — were loaded into one process and run over the five dumps in `data/` (sakila, OKKY, GNUBOARD5, YOUNGCART5, Magento2-sales: 194 tables, 3083 columns). Every table was compared field by field. The output differs in exactly one place:

  ```
  ~ sakila customer comment "" -> "Table storing all customers. Holds foreign keys to …"
  ```

  That is the #379 fix reading a comment for the first time. Nothing else moved.
- Four independent review agents went over the diff and 19 claims were each handed to a verifier told to refute them. The two that survived were both regressions this branch had introduced — the `;` and the `(` inside a comment described above. Both are fixed and covered by tests; the whole loop was re-run after.

## Left alone, worth separate issues

Each verified identical on this branch and on `main`:

- **`ON DELETE` / `ON UPDATE` produce phantom columns named `ON`.** 12 of the 16 tables in `data/sakila.sql`, e.g. `payment: …, last_update, ON, ON, ON`. `FULLTEXT KEY` and a `KEY` clause's own name leak in the same way (`store: …, idx_unique_manager, ON, ON`).
- **Multi-word types collapse to one word**: `DOUBLE PRECISION` → `DOUBLE`, `CHARACTER VARYING(30)` → `CHARACTER`, `TIMESTAMP WITH TIME ZONE` → `TIME`.
- **`CREATE INDEX i ON public.users (email)`** yields `tableName: "public"` and no columns — the index parser handles no qualified name, unlike the three `alter.table.add.*` parsers.
- **A three-part name keeps the middle segment**: `db.sch.t` becomes `sch`.
- **`''` inside a literal truncates it.** `COMMENT='it''s'` imports as `it`. Fixing the round trip needs the exporters too — `PostgreSQL.ts` and the others interpolate a comment raw, so a comment holding an apostrophe is emitted as invalid SQL in the first place.
- **MSSQL comments never import.** That exporter writes `EXEC sys.sp_addextendedproperty`, which the parser does not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
