### PR TITLE
feat(erd-editor): Thin the relationship connectors and their cardinality symbols

### DIFF
--- a/packages/erd-editor/e2e/bench/README.md
+++ b/packages/erd-editor/e2e/bench/README.md
@@ -86,10 +86,22 @@ happened to sit near a table box and reported whatever it found, including
 nothing at all once stub lengths changed.
 
 `collinear px` is how far two connectors run side by side within one stroke
-width of each other — 3px, the width they are drawn at. It is a visual
-complaint, so the threshold is the stroke and not equality. Pairs are compared
+width of each other, read from `RELATIONSHIP_STROKE_WIDTH`. It is a visual
+complaint, so the threshold is a band and not equality. Pairs are compared
 directly rather than bucketed: a band is not an equivalence relation, and
 clustering chains 0-3-6-9 into one group.
+
+**Every `collinear px` figure recorded below was measured at a band of 3**, the
+width connectors were drawn at then. They are drawn at 2 now and the band
+followed, so those figures read high against a run made today: the same routing
+scores 0 / 0 / 2721 under the current band where it scored 0 / 168 / 2943 under
+the old one. Nothing moved — thinning the connector cleared the medium corpus on
+its own, and the wider band had been counting pairs a reader can now separate.
+
+Do not hold the band still to keep old numbers comparable. A band wider than the
+stroke puts a rung of `NUDGE_GAPS` exactly on its boundary, where floating point
+drops it inside: measured at 3 against a 2px connector, adding a 3px rung looked
+like a 188% collinear regression when its real cost was 0 → 316px on medium.
 
 ## Comparing runs
 
@@ -192,7 +204,7 @@ the metric by whether both segments are ones the pass may move puts medium's who
 168px, and 1121px of large's, between runs attached to an anchor — a connector's
 first and last run, whose coordinate is the anchor's and not the route's, and which
 nothing here can move. The other 1822px of large's is a group spreading outward and
-landing within a stroke width of a segment in a channel it was not grouped with.
+landing within the band of a segment in a channel it was not grouped with.
 Small has none of either.
 
 **What it costs.** Measured alternately, three rounds each, `busy/move` ran

--- a/packages/erd-editor/e2e/bench/geometry.ts
+++ b/packages/erd-editor/e2e/bench/geometry.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test';
 
+import { RELATIONSHIP_STROKE_WIDTH } from '@/constants/layout';
+
 /**
  * Overlap metrics, computed from what the editor actually drew.
  *
@@ -82,10 +84,12 @@ export type QualityMetrics = {
  * coordinates.
  *
  * `Relationship.tsx` renders the routing polyline as one `path.route` and every
- * cardinality decoration as a bare `stroke-width="3"` line, so the route is read
- * back out of that path's `d` — a run of `M`/`L` points, contiguous by
- * construction. Scoping to `[data-testid="erd-canvas"]` keeps the minimap's
- * second copy of the same SVG out of the count.
+ * cardinality decoration as a bare `<line>`, so the route is read back out of
+ * that path's `d` — a run of `M`/`L` points, contiguous by construction. The
+ * class is what selects it: the same `<g>` also holds a `path.hit-area` with the
+ * same shape, and counting both would double every segment. Scoping to
+ * `[data-testid="erd-canvas"]` keeps the minimap's second copy of the same SVG
+ * out of the count.
  */
 export async function readScene(page: Page): Promise<Scene> {
   return page.evaluate(() => {
@@ -223,16 +227,27 @@ function segmentIntersectsRect(segment: Segment, rect: TableRect) {
 /**
  * How far two connectors run side by side close enough to read as one line.
  *
- * The reader's complaint is visual, so the threshold is the stroke width, not
- * equality. An earlier version bucketed segments by their coordinate rounded to
- * one decimal, which answers a different question — how often two segments land
+ * The reader's complaint is visual, not equality. An earlier version bucketed
+ * segments by their coordinate rounded to one decimal, which answers a different
+ * question — how often two segments land
  * on the *identical* line — and that question flatters any change that moves a
  * shared channel by a pixel. It reported zero for the medium corpus while the
  * same scene held 2008px of overlap a reader cannot distinguish from a single
  * connector. Pairs are compared directly rather than clustered: clustering
  * chains 0-3-6-9 into one group, and a band is not an equivalence relation.
+ *
+ * Read from the width the editor draws with, so it cannot drift from the
+ * picture it is a complaint about: two connectors are within a band of each
+ * other exactly when their strokes overlap. It was 3 while the connector was,
+ * and followed it to 2 — figures recorded under the old band read high by
+ * comparison and are marked as such in `README.md`.
+ *
+ * A stale band is not a harmless conservatism. At 3 against a 2px connector a
+ * pair separated by exactly 3 sits on the boundary and floating point drops it
+ * inside, which is what made a 3px rung of `NUDGE_GAPS` look like a 188%
+ * regression when its real cost was a tenth of that.
  */
-const STROKE_WIDTH = 3;
+const OVERLAP_BAND = RELATIONSHIP_STROKE_WIDTH;
 
 type Run = {
   low: number;
@@ -241,7 +256,7 @@ type Run = {
   relationshipId: string;
 };
 
-export function collinearOverlap(segments: Segment[], band = STROKE_WIDTH) {
+export function collinearOverlap(segments: Segment[], band = OVERLAP_BAND) {
   const byAxis: Record<'h' | 'v', Run[]> = { h: [], v: [] };
 
   for (const segment of segments) {

--- a/packages/erd-editor/e2e/specs/relationship.spec.ts
+++ b/packages/erd-editor/e2e/specs/relationship.spec.ts
@@ -19,6 +19,8 @@ const only = <T>(values: T[]): T => {
  * | part         | elements                                                   |
  * | ------------ | ---------------------------------------------------------- |
  * | routing path | one `path.route`, dashed unless the relationship identifies |
+ * | hit band     | one `path.hit-area`, transparent and wider — the pointer    |
+ * |              | target, which is why neither count below covers it          |
  * | start marker | 4 `<line>` — the stem, base, base2 and center2 of the       |
  * |              | `dash` start, which is what a `notNull` end column selects  |
  * | end marker   | varies per type, below — this is the cardinality symbol     |

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/CanvasSvg.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/CanvasSvg.test.ts
@@ -71,13 +71,18 @@ describe('CanvasSvg', () => {
     expect(groups.map(g => g.getAttribute('data-id'))).toEqual(['r1', 'r2']);
   });
 
-  it('defaults the relationship stroke width to 3', async () => {
+  it('defaults the relationship stroke width to 2', async () => {
     mounted = await mountAndFlush(svg`<${CanvasSvg} />`);
     mounted.app.store.dispatchSync(addRelationship('r1'));
     await flush();
 
-    const line = root().querySelector('g.relationship line') as SVGLineElement;
-    expect(line.getAttribute('stroke-width')).toBe('3');
+    // The route, not a decoration: every decoration carries the same width from
+    // the same constant, so reading one of those passes whatever the prop
+    // default is and covers nothing.
+    const route = root().querySelector(
+      'g.relationship path.route'
+    ) as SVGPathElement;
+    expect(route.getAttribute('stroke-width')).toBe('2');
   });
 
   it('forwards the strokeWidth prop to every relationship', async () => {

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/CanvasSvg.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/CanvasSvg.tsx
@@ -3,6 +3,7 @@ import { FC, repeat } from '@dineug/r-html';
 
 import { useAppContext } from '@/components/appContext';
 import Relationship from '@/components/erd/canvas/canvas-svg/relationship/Relationship';
+import { RELATIONSHIP_STROKE_WIDTH } from '@/constants/layout';
 
 import * as styles from './CanvasSvg.styles';
 
@@ -42,7 +43,7 @@ const CanvasSvg: FC<CanvasSvgProps> = (props, ctx) => {
           relationship => (
             <Relationship
               relationship={relationship}
-              strokeWidth={props.strokeWidth ?? 3}
+              strokeWidth={props.strokeWidth ?? RELATIONSHIP_STROKE_WIDTH}
             />
           )
         )}

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.template.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.template.test.ts
@@ -83,7 +83,7 @@ describe('relationshipShape', () => {
     expect(xy(lines[0])).toEqual(toXY(path.path.line.end));
     expect(circles[0].getAttribute('cx')).toBe(`${path.line.circle.cx}`);
     expect(circles[0].getAttribute('cy')).toBe(`${path.line.circle.cy}`);
-    expect(circles[0].getAttribute('r')).toBe('8');
+    expect(circles[0].getAttribute('r')).toBe('6');
     expect(circles[0].getAttribute('fill-opacity')).toBe('0.0');
     expect(xy(lines[1])).toEqual(toXY(path.line.line.end.base));
     expect(xy(lines[2])).toEqual(toXY(path.line.line.end.left));
@@ -163,12 +163,39 @@ describe('relationshipShape', () => {
     expect(xy(lines[3])).toEqual(toXY(path.line.line.end.right));
   });
 
-  it('gives every rendered segment a stroke-width of 3', async () => {
-    const path = createPath();
-    const { lines, circles } = await renderShape(ZERO_ONE_N, path);
+  // Every shape in the map, not just one of them: the widths are seven separate
+  // literals per shape and a sweep that leaves one behind draws a single
+  // cardinality symbol at the old weight.
+  const EVERY_SHAPE = [
+    ['zero-one-n', ZERO_ONE_N],
+    ['zero-one', RelationshipType.ZeroOne],
+    ['zero-n', RelationshipType.ZeroN],
+    ['one-only', RelationshipType.OneOnly],
+    ['one-n', RelationshipType.OneN],
+    ['one', ONE],
+    ['n', N],
+  ] as const;
 
-    for (const el of [...lines, ...circles]) {
-      expect(el.getAttribute('stroke-width')).toBe('3');
-    }
-  });
+  for (const [name, relationshipType] of EVERY_SHAPE) {
+    it(`gives every segment of the ${name} shape a stroke-width of 2`, async () => {
+      const path = createPath();
+      const { lines, circles } = await renderShape(relationshipType, path);
+
+      expect(lines.length).toBeGreaterThan(0);
+      for (const el of [...lines, ...circles]) {
+        expect(el.getAttribute('stroke-width')).toBe('2');
+      }
+    });
+  }
+
+  for (const [name, relationshipType] of EVERY_SHAPE) {
+    it(`draws every ring of the ${name} shape at the shared radius`, async () => {
+      const path = createPath();
+      const { circles } = await renderShape(relationshipType, path);
+
+      for (const el of circles) {
+        expect(el.getAttribute('r')).toBe('6');
+      }
+    });
+  }
 });

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.template.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.template.tsx
@@ -1,7 +1,8 @@
 import { DOMTemplateLiterals } from '@dineug/r-html';
 
+import { RELATIONSHIP_STROKE_WIDTH } from '@/constants/layout';
 import { RelationshipType } from '@/constants/schema';
-import { RelationshipPath } from '@/utils/draw-relationship';
+import { CIRCLE_RADIUS, RelationshipPath } from '@/utils/draw-relationship';
 
 const relationshipZeroOneN = ({ path, line }: RelationshipPath) => (
   <>
@@ -10,42 +11,42 @@ const relationshipZeroOneN = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <circle
       cx={line.circle.cx}
       cy={line.circle.cy}
-      r="8"
+      r={CIRCLE_RADIUS}
       fill-opacity="0.0"
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></circle>
     <line
       x1={line.line.end.base.x1}
       y1={line.line.end.base.y1}
       x2={line.line.end.base.x2}
       y2={line.line.end.base.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.left.x1}
       y1={line.line.end.left.y1}
       x2={line.line.end.left.x2}
       y2={line.line.end.left.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center.x1}
       y1={line.line.end.center.y1}
       x2={line.line.end.center.x2}
       y2={line.line.end.center.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.right.x1}
       y1={line.line.end.right.y1}
       x2={line.line.end.right.x2}
       y2={line.line.end.right.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -57,28 +58,28 @@ const relationshipZeroOne = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <circle
       cx={line.circle.cx}
       cy={line.circle.cy}
-      r="8"
+      r={CIRCLE_RADIUS}
       fill-opacity="0.0"
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></circle>
     <line
       x1={line.line.end.base.x1}
       y1={line.line.end.base.y1}
       x2={line.line.end.base.x2}
       y2={line.line.end.base.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center.x1}
       y1={line.line.end.center.y1}
       x2={line.line.end.center.x2}
       y2={line.line.end.center.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -90,35 +91,35 @@ const relationshipZeroN = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <circle
       cx={line.circle.cx}
       cy={line.circle.cy}
-      r="8"
+      r={CIRCLE_RADIUS}
       fill-opacity="0.0"
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></circle>
     <line
       x1={line.line.end.left.x1}
       y1={line.line.end.left.y1}
       x2={line.line.end.left.x2}
       y2={line.line.end.left.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center.x1}
       y1={line.line.end.center.y1}
       x2={line.line.end.center.x2}
       y2={line.line.end.center.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.right.x1}
       y1={line.line.end.right.y1}
       x2={line.line.end.right.x2}
       y2={line.line.end.right.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -130,28 +131,28 @@ const relationshipOneOnly = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.base.x1}
       y1={line.line.end.base.y1}
       x2={line.line.end.base.x2}
       y2={line.line.end.base.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.base2.x1}
       y1={line.line.end.base2.y1}
       x2={line.line.end.base2.x2}
       y2={line.line.end.base2.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center2.x1}
       y1={line.line.end.center2.y1}
       x2={line.line.end.center2.x2}
       y2={line.line.end.center2.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -163,35 +164,35 @@ const relationshipOneN = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.base.x1}
       y1={line.line.end.base.y1}
       x2={line.line.end.base.x2}
       y2={line.line.end.base.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.left.x1}
       y1={line.line.end.left.y1}
       x2={line.line.end.left.x2}
       y2={line.line.end.left.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center2.x1}
       y1={line.line.end.center2.y1}
       x2={line.line.end.center2.x2}
       y2={line.line.end.center2.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.right.x1}
       y1={line.line.end.right.y1}
       x2={line.line.end.right.x2}
       y2={line.line.end.right.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -203,21 +204,21 @@ const relationshipOne = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.base.x1}
       y1={line.line.end.base.y1}
       x2={line.line.end.base.x2}
       y2={line.line.end.base.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center2.x1}
       y1={line.line.end.center2.y1}
       x2={line.line.end.center2.x2}
       y2={line.line.end.center2.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );
@@ -229,28 +230,28 @@ const relationshipN = ({ path, line }: RelationshipPath) => (
       y1={path.line.end.y1}
       x2={path.line.end.x2}
       y2={path.line.end.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.left.x1}
       y1={line.line.end.left.y1}
       x2={line.line.end.left.x2}
       y2={line.line.end.left.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.center2.x1}
       y1={line.line.end.center2.y1}
       x2={line.line.end.center2.x2}
       y2={line.line.end.center2.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
     <line
       x1={line.line.end.right.x1}
       y1={line.line.end.right.y1}
       x2={line.line.end.right.x2}
       y2={line.line.end.right.y2}
-      stroke-width="3"
+      stroke-width={RELATIONSHIP_STROKE_WIDTH}
     ></line>
   </>
 );

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.test.ts
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, it } from 'vite-plus/test';
 import { flush, mountAndFlush, Mounted } from '@/__test-utils__/index';
 import Relationship from '@/components/erd/canvas/canvas-svg/relationship/Relationship';
 import {
+  RELATIONSHIP_HIT_STROKE_WIDTH,
+  RELATIONSHIP_STROKE_WIDTH,
+} from '@/constants/layout';
+import {
   Direction,
   RelationshipType,
   StartRelationshipType,
@@ -47,7 +51,10 @@ afterEach(() => {
   mounted = null;
 });
 
-const mountRelationship = (relationship: RelationshipType_, strokeWidth = 3) =>
+const mountRelationship = (
+  relationship: RelationshipType_,
+  strokeWidth = RELATIONSHIP_STROKE_WIDTH
+) =>
   mountAndFlush(
     svg`<svg><${Relationship} relationship=${relationship} strokeWidth=${strokeWidth} /></svg>`
   );
@@ -139,8 +146,65 @@ describe('Relationship', () => {
     // Every remaining line is a cardinality decoration, drawn at a fixed width.
     const lines = Array.from(mounted.container.querySelectorAll('line'));
     lines.forEach(line => {
-      expect(line.getAttribute('stroke-width')).toBe('3');
+      expect(line.getAttribute('stroke-width')).toBe('2');
     });
+  });
+
+  it('lays a pointer band over the connector that is wider than the drawing', async () => {
+    mounted = await mountRelationship(makeRelationship());
+
+    const hit = mounted.container.querySelector(
+      'path.hit-area'
+    ) as SVGPathElement;
+    expect(Number(hit.getAttribute('stroke-width'))).toBe(
+      RELATIONSHIP_HIT_STROKE_WIDTH
+    );
+    expect(RELATIONSHIP_HIT_STROKE_WIDTH).toBeGreaterThan(
+      RELATIONSHIP_STROKE_WIDTH
+    );
+    // Only the stroke is a target: a filled interior would swallow the canvas
+    // enclosed by the bends.
+    expect(hit.getAttribute('fill')).toBe('none');
+    expect(hit.getAttribute('pointer-events')).toBe('stroke');
+    // `CanvasSvg.styles.ts` strokes the group and lets the shapes inherit it,
+    // so the band needs a paint of its own — a presentation attribute, which
+    // applies to the element and therefore beats what it would inherit.
+    expect(hit.getAttribute('stroke')).toBe('transparent');
+  });
+
+  it('keeps the pointer band solid while the route it covers is dashed', async () => {
+    mounted = await mountRelationship(makeRelationship());
+
+    // A dash gap is unpainted and therefore not a target, so a banded copy of
+    // the route's dasharray would leave half the connector unhoverable.
+    const route = mounted.container.querySelector(
+      'path.route'
+    ) as SVGPathElement;
+    expect(route.getAttribute('stroke-dasharray')).toBe('10');
+    expect(
+      mounted.container
+        .querySelector('path.hit-area')
+        ?.hasAttribute('stroke-dasharray')
+    ).toBe(false);
+  });
+
+  it('runs the pointer band from one cardinality decoration to the other', async () => {
+    const relationship = makeRelationship();
+    const { path } = getRelationshipPath(relationship);
+    mounted = await mountRelationship(relationship);
+
+    const d =
+      mounted.container.querySelector('path.hit-area')?.getAttribute('d') ?? '';
+    const numbers = (d.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
+
+    // The route alone spans the two turning points. The guide lines either side
+    // of it carry the connector the rest of the way to its decorations, and
+    // they are as thin as the route — so the band has to cover them too.
+    expect(numbers.slice(0, 2)).toEqual([
+      path.line.start.x1,
+      path.line.start.y1,
+    ]);
+    expect(numbers.slice(-2)).toEqual([path.line.end.x1, path.line.end.y1]);
   });
 
   it('renders the dash start marker for a dash start relationship type', async () => {
@@ -172,6 +236,16 @@ describe('Relationship', () => {
     expect(circles).toHaveLength(2);
     expect(circles[0].getAttribute('cx')).toBe(`${line.startCircle.cx}`);
     expect(circles[0].getAttribute('cy')).toBe(`${line.startCircle.cy}`);
+
+    // The ring branch renders markup the dash branch never does, and every
+    // other mount in this file takes the dash branch.
+    for (const el of [
+      ...circles,
+      ...Array.from(mounted.container.querySelectorAll('line')),
+    ]) {
+      expect(el.getAttribute('stroke-width')).toBe('2');
+    }
+    expect(circles[0].getAttribute('r')).toBe('6');
   });
 
   it('omits the end shape when the relationship type has no registered shape', async () => {

--- a/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/canvas-svg/relationship/Relationship.tsx
@@ -1,15 +1,46 @@
 import { FC } from '@dineug/r-html';
 
 import { useAppContext } from '@/components/appContext';
+import {
+  RELATIONSHIP_HIT_STROKE_WIDTH,
+  RELATIONSHIP_STROKE_WIDTH,
+} from '@/constants/layout';
 import { StartRelationshipType } from '@/constants/schema';
 import { hoverColumnMapAction } from '@/engine/modules/editor/atom.actions';
-import { Relationship as RelationshipType } from '@/internal-types';
+import { Point, Relationship as RelationshipType } from '@/internal-types';
+import { CIRCLE_RADIUS, RelationshipPath } from '@/utils/draw-relationship';
 import {
   getRelationshipPath,
   toPathD,
 } from '@/utils/draw-relationship/pathFinding';
 
 import { relationshipShape } from './Relationship.template';
+
+/**
+ * The whole connector as one path, from one cardinality decoration to the other.
+ *
+ * Only for hit-testing: a pointer finds an SVG path along its painted stroke, so
+ * a connector is exactly as easy to hover as it is thick — and thinning it to
+ * `RELATIONSHIP_STROKE_WIDTH` halved a target that was already the width of a
+ * line. The guide lines either side of the route start and end where the route
+ * does, so all three fit in one extra element instead of one band per segment.
+ */
+function toHitPathD(
+  { line }: RelationshipPath['path'],
+  segments: Array<[Point, Point]>
+) {
+  return toPathD([
+    [
+      { x: line.start.x1, y: line.start.y1 },
+      { x: line.start.x2, y: line.start.y2 },
+    ],
+    ...segments,
+    [
+      { x: line.end.x2, y: line.end.y2 },
+      { x: line.end.x1, y: line.end.y1 },
+    ],
+  ]);
+}
 
 export type RelationshipProps = {
   relationship: RelationshipType;
@@ -61,6 +92,14 @@ const Relationship: FC<RelationshipProps> = (props, ctx) => {
         on:mouseleave={handleMouseleave}
       >
         <path
+          class="hit-area"
+          d={toHitPathD(path, lines)}
+          stroke-width={RELATIONSHIP_HIT_STROKE_WIDTH}
+          stroke="transparent"
+          pointer-events="stroke"
+          fill="none"
+        ></path>
+        <path
           class="route"
           d={toPathD(lines)}
           stroke-dasharray={relationship.identification ? 0 : 10}
@@ -72,30 +111,30 @@ const Relationship: FC<RelationshipProps> = (props, ctx) => {
           y1={path.line.start.y1}
           x2={path.line.start.x2}
           y2={path.line.start.y2}
-          stroke-width="3"
+          stroke-width={RELATIONSHIP_STROKE_WIDTH}
         ></line>
         <line
           x1={line.line.start.base.x1}
           y1={line.line.start.base.y1}
           x2={line.line.start.base.x2}
           y2={line.line.start.base.y2}
-          stroke-width="3"
+          stroke-width={RELATIONSHIP_STROKE_WIDTH}
         ></line>
         {relationship.startRelationshipType === StartRelationshipType.ring ? (
           <>
             <circle
               cx={line.startCircle.cx}
               cy={line.startCircle.cy}
-              r="8"
+              r={CIRCLE_RADIUS}
               fill-opacity="0.0"
-              stroke-width="3"
+              stroke-width={RELATIONSHIP_STROKE_WIDTH}
             ></circle>
             <line
               x1={line.line.start.center.x1}
               y1={line.line.start.center.y1}
               x2={line.line.start.center.x2}
               y2={line.line.start.center.y2}
-              stroke-width="3"
+              stroke-width={RELATIONSHIP_STROKE_WIDTH}
             ></line>
           </>
         ) : (
@@ -105,14 +144,14 @@ const Relationship: FC<RelationshipProps> = (props, ctx) => {
               y1={line.line.start.base2.y1}
               x2={line.line.start.base2.x2}
               y2={line.line.start.base2.y2}
-              stroke-width="3"
+              stroke-width={RELATIONSHIP_STROKE_WIDTH}
             ></line>
             <line
               x1={line.line.start.center2.x1}
               y1={line.line.start.center2.y1}
               x2={line.line.start.center2.x2}
               y2={line.line.start.center2.y2}
-              stroke-width="3"
+              stroke-width={RELATIONSHIP_STROKE_WIDTH}
             ></line>
           </>
         )}

--- a/packages/erd-editor/src/components/erd/canvas/draw-relationship/DrawRelationship.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/draw-relationship/DrawRelationship.test.ts
@@ -82,7 +82,7 @@ describe('DrawRelationship', () => {
     expect(path.getAttribute('d')).toBe(expected.path.path.d());
     expect(path.getAttribute('stroke-dasharray')).toBe('10');
     expect(path.getAttribute('fill')).toBe('transparent');
-    expect(path.getAttribute('stroke-width')).toBe('3');
+    expect(path.getAttribute('stroke-width')).toBe('2');
   });
 
   it('renders the start tick, base, base2 and center2 markers', async () => {
@@ -110,7 +110,7 @@ describe('DrawRelationship', () => {
     expect(xy(lines[1])).toEqual(toXY(line.start.base));
     expect(xy(lines[2])).toEqual(toXY(line.start.base2));
     expect(xy(lines[3])).toEqual(toXY(line.start.center2));
-    lines.forEach(el => expect(el.getAttribute('stroke-width')).toBe('3'));
+    lines.forEach(el => expect(el.getAttribute('stroke-width')).toBe('2'));
   });
 
   it('falls back to a degenerate path when the draw has no start point', async () => {

--- a/packages/erd-editor/src/components/erd/canvas/draw-relationship/DrawRelationship.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/draw-relationship/DrawRelationship.tsx
@@ -2,6 +2,7 @@ import { FC, onMounted, Ref } from '@dineug/r-html';
 import { fromEvent } from 'rxjs';
 
 import { useAppContext } from '@/components/appContext';
+import { RELATIONSHIP_STROKE_WIDTH } from '@/constants/layout';
 import { drawRelationshipAction } from '@/engine/modules/editor/atom.actions';
 import { DrawRelationship as DrawRelationshipType } from '@/engine/modules/editor/state';
 import { useUnmounted } from '@/hooks/useUnmounted';
@@ -60,7 +61,7 @@ const DrawRelationship: FC<DrawRelationshipProps> = (props, ctx) => {
             class="draw-preview"
             d={path.path.d()}
             stroke-dasharray="10"
-            stroke-width="3"
+            stroke-width={RELATIONSHIP_STROKE_WIDTH}
             fill="transparent"
           ></path>
           <line
@@ -68,28 +69,28 @@ const DrawRelationship: FC<DrawRelationshipProps> = (props, ctx) => {
             y1={path.line.start.y1}
             x2={path.line.start.x2}
             y2={path.line.start.y2}
-            stroke-width="3"
+            stroke-width={RELATIONSHIP_STROKE_WIDTH}
           ></line>
           <line
             x1={line.start.base.x1}
             y1={line.start.base.y1}
             x2={line.start.base.x2}
             y2={line.start.base.y2}
-            stroke-width="3"
+            stroke-width={RELATIONSHIP_STROKE_WIDTH}
           ></line>
           <line
             x1={line.start.base2.x1}
             y1={line.start.base2.y1}
             x2={line.start.base2.x2}
             y2={line.start.base2.y2}
-            stroke-width="3"
+            stroke-width={RELATIONSHIP_STROKE_WIDTH}
           ></line>
           <line
             x1={line.start.center2.x1}
             y1={line.start.center2.y1}
             x2={line.start.center2.x2}
             y2={line.start.center2.y2}
-            stroke-width="3"
+            stroke-width={RELATIONSHIP_STROKE_WIDTH}
           ></line>
         </g>
       </svg>

--- a/packages/erd-editor/src/components/erd/minimap/Minimap.test.ts
+++ b/packages/erd-editor/src/components/erd/minimap/Minimap.test.ts
@@ -11,8 +11,10 @@ import { AppContext } from '@/components/appContext';
 import * as canvasStyles from '@/components/erd/canvas/Canvas.styles';
 import Minimap from '@/components/erd/minimap/Minimap';
 import * as styles from '@/components/erd/minimap/Minimap.styles';
-import { Show } from '@/constants/schema';
+import { RELATIONSHIP_STROKE_WIDTH } from '@/constants/layout';
+import { RelationshipType, Show } from '@/constants/schema';
 import { addMemoAction } from '@/engine/modules/memo/atom.actions';
+import { addRelationshipAction } from '@/engine/modules/relationship/atom.actions';
 import {
   changeShowAction,
   changeZoomLevelAction,
@@ -149,6 +151,31 @@ describe('Minimap', () => {
     await flush();
 
     expect(minimapOf().querySelector('svg')).toBeNull();
+  });
+
+  it('draws the relationship route far thicker than the canvas does', async () => {
+    const app = createTestAppContext();
+    await mount_(app);
+
+    app.store.dispatchSync(
+      addRelationshipAction({
+        id: 'r1',
+        relationshipType: RelationshipType.ZeroOne,
+        start: { tableId: 'table-a', columnIds: ['c1'] },
+        end: { tableId: 'table-b', columnIds: ['c2'] },
+      })
+    );
+    await flush();
+
+    // The minimap scales the canvas down by `MINIMAP_SIZE / settings.width`, so
+    // the route would be a fraction of a device pixel at the width the canvas
+    // draws it. This number is a legibility floor of its own and is not derived
+    // from `RELATIONSHIP_STROKE_WIDTH`.
+    const route = minimapOf().querySelector('svg path.route');
+    expect(route?.getAttribute('stroke-width')).toBe('12');
+    expect(Number(route?.getAttribute('stroke-width'))).toBeGreaterThan(
+      RELATIONSHIP_STROKE_WIDTH
+    );
   });
 
   it('scrolls the canvas so the pressed point becomes the viewport center', async () => {

--- a/packages/erd-editor/src/components/erd/minimap/Minimap.tsx
+++ b/packages/erd-editor/src/components/erd/minimap/Minimap.tsx
@@ -145,6 +145,12 @@ const Minimap: FC<MinimapProps> = (props, ctx) => {
               )
             )}
             {bHas(show, Show.relationship) ? (
+              // Not a multiple of what the canvas draws. The minimap scales the
+              // whole canvas by `MINIMAP_SIZE / settings.width` — 0.075 at the
+              // default width, less on a bigger canvas — so a connector at the
+              // canvas width would land far under one device pixel here. 12 is
+              // the floor that keeps the route near a pixel in a 150px
+              // thumbnail, and it does not move when the canvas stroke does.
               <CanvasSvg class={styles.canvasSvg} strokeWidth={12} />
             ) : null}
           </div>

--- a/packages/erd-editor/src/constants/layout.test.ts
+++ b/packages/erd-editor/src/constants/layout.test.ts
@@ -23,6 +23,8 @@ import {
   MEMO_PADDING,
   MINIMAP_MARGIN,
   MINIMAP_SIZE,
+  RELATIONSHIP_HIT_STROKE_WIDTH,
+  RELATIONSHIP_STROKE_WIDTH,
   START_ADD,
   START_X,
   START_Y,
@@ -117,6 +119,16 @@ describe('layout constants', () => {
     expect(DIFF_TREE_WIDTH).toBe(200);
   });
 
+  it('draws the connector thinner than the band that catches the pointer', () => {
+    expect(RELATIONSHIP_STROKE_WIDTH).toBe(2);
+    expect(RELATIONSHIP_HIT_STROKE_WIDTH).toBe(8);
+    // Hit-testing follows the painted stroke, so the band is the whole reason a
+    // connector this thin is still reachable.
+    expect(RELATIONSHIP_HIT_STROKE_WIDTH).toBeGreaterThan(
+      RELATIONSHIP_STROKE_WIDTH
+    );
+  });
+
   it('exports only finite positive numbers', () => {
     const values = [
       START_X,
@@ -152,6 +164,8 @@ describe('layout constants', () => {
       MINIMAP_MARGIN,
       TOOLBAR_HEIGHT,
       DIFF_TREE_WIDTH,
+      RELATIONSHIP_STROKE_WIDTH,
+      RELATIONSHIP_HIT_STROKE_WIDTH,
     ];
 
     for (const value of values) {

--- a/packages/erd-editor/src/constants/layout.ts
+++ b/packages/erd-editor/src/constants/layout.ts
@@ -48,3 +48,24 @@ export const MINIMAP_MARGIN = 20;
 export const TOOLBAR_HEIGHT = 30;
 
 export const DIFF_TREE_WIDTH = 200;
+
+/**
+ * How thick a relationship connector is drawn.
+ *
+ * Down from 3: the thick line ate the gap between neighbouring tables and made a
+ * busy diagram read as a mass of strokes rather than as connections. A whole
+ * number rather than 1.5, so the stroke lands on pixel boundaries instead of
+ * being spread across two rows at partial alpha on a 1x display.
+ */
+export const RELATIONSHIP_STROKE_WIDTH = 2;
+
+/**
+ * The width of the invisible band that catches the pointer for a connector.
+ *
+ * Hit-testing an SVG path follows its painted stroke, so halving the stroke
+ * would otherwise halve the target the user has to hit to hover a relationship
+ * or open its context menu. `NUDGE_GAP` is 10, so a band this wide stays clear
+ * of the neighbouring corridor except where the router had to fall back to a
+ * narrower gap.
+ */
+export const RELATIONSHIP_HIT_STROKE_WIDTH = 8;

--- a/packages/erd-editor/src/utils/draw-relationship/draw.test.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/draw.test.ts
@@ -74,7 +74,7 @@ describe('getDraw', () => {
       });
       expect(result.path.line.start).toEqual({
         x1: CENTER_X,
-        y1: TABLE_HEIGHT + 35,
+        y1: TABLE_HEIGHT + 25,
         x2: CENTER_X,
         y2: TABLE_HEIGHT + 50,
       });
@@ -89,26 +89,26 @@ describe('getDraw', () => {
       const { line } = getDraw(state, draw);
 
       expect(line.start.base).toEqual({
-        x1: CENTER_X - 10,
-        y1: TABLE_HEIGHT + 16,
-        x2: CENTER_X + 10,
-        y2: TABLE_HEIGHT + 16,
+        x1: CENTER_X - 7,
+        y1: TABLE_HEIGHT + 11,
+        x2: CENTER_X + 7,
+        y2: TABLE_HEIGHT + 11,
       });
       expect(line.start.base2).toEqual({
-        x1: CENTER_X - 10,
-        y1: TABLE_HEIGHT + 26,
-        x2: CENTER_X + 10,
-        y2: TABLE_HEIGHT + 26,
+        x1: CENTER_X - 7,
+        y1: TABLE_HEIGHT + 18,
+        x2: CENTER_X + 7,
+        y2: TABLE_HEIGHT + 18,
       });
       expect(line.start.center).toEqual({
         x1: CENTER_X,
-        y1: TABLE_HEIGHT + 16,
+        y1: TABLE_HEIGHT + 11,
         x2: CENTER_X,
         y2: TABLE_HEIGHT,
       });
       expect(line.start.center2).toEqual({
         x1: CENTER_X,
-        y1: TABLE_HEIGHT + 35,
+        y1: TABLE_HEIGHT + 25,
         x2: CENTER_X,
         y2: TABLE_HEIGHT,
       });
@@ -138,7 +138,7 @@ describe('getDraw', () => {
       expect(draw.start).toEqual({ tableId: 'table-a', x: CENTER_X, y: 0 });
       expect(result.path.line.start).toEqual({
         x1: CENTER_X,
-        y1: -35,
+        y1: -25,
         x2: CENTER_X,
         y2: -50,
       });
@@ -146,26 +146,26 @@ describe('getDraw', () => {
       expect(result.path.path.L).toEqual({ x: CENTER_X, y: -500 });
       expect(result.path.path.d()).toBe('M 182.5 -50 L 182.5 -500');
       expect(result.line.start.base).toEqual({
-        x1: CENTER_X - 10,
-        y1: -16,
-        x2: CENTER_X + 10,
-        y2: -16,
+        x1: CENTER_X - 7,
+        y1: -11,
+        x2: CENTER_X + 7,
+        y2: -11,
       });
       expect(result.line.start.base2).toEqual({
-        x1: CENTER_X - 10,
-        y1: -26,
-        x2: CENTER_X + 10,
-        y2: -26,
+        x1: CENTER_X - 7,
+        y1: -18,
+        x2: CENTER_X + 7,
+        y2: -18,
       });
       expect(result.line.start.center).toEqual({
         x1: CENTER_X,
-        y1: -16,
+        y1: -11,
         x2: CENTER_X,
         y2: 0,
       });
       expect(result.line.start.center2).toEqual({
         x1: CENTER_X,
-        y1: -35,
+        y1: -25,
         x2: CENTER_X,
         y2: 0,
       });
@@ -180,7 +180,7 @@ describe('getDraw', () => {
 
       expect(draw.start).toEqual({ tableId: 'table-a', x: 0, y: CENTER_Y });
       expect(result.path.line.start).toEqual({
-        x1: -35,
+        x1: -25,
         y1: CENTER_Y,
         x2: -50,
         y2: CENTER_Y,
@@ -189,25 +189,25 @@ describe('getDraw', () => {
       expect(result.path.path.L).toEqual({ x: -500, y: CENTER_Y });
       expect(result.path.path.d()).toBe('M -50 28 L -500 28');
       expect(result.line.start.base).toEqual({
-        x1: -16,
-        y1: CENTER_Y - 10,
-        x2: -16,
-        y2: CENTER_Y + 10,
+        x1: -11,
+        y1: CENTER_Y - 7,
+        x2: -11,
+        y2: CENTER_Y + 7,
       });
       expect(result.line.start.base2).toEqual({
-        x1: -26,
-        y1: CENTER_Y - 10,
-        x2: -26,
-        y2: CENTER_Y + 10,
+        x1: -18,
+        y1: CENTER_Y - 7,
+        x2: -18,
+        y2: CENTER_Y + 7,
       });
       expect(result.line.start.center).toEqual({
-        x1: -16,
+        x1: -11,
         y1: CENTER_Y,
         x2: 0,
         y2: CENTER_Y,
       });
       expect(result.line.start.center2).toEqual({
-        x1: -35,
+        x1: -25,
         y1: CENTER_Y,
         x2: 0,
         y2: CENTER_Y,
@@ -227,7 +227,7 @@ describe('getDraw', () => {
         y: CENTER_Y,
       });
       expect(result.path.line.start).toEqual({
-        x1: TABLE_WIDTH + 35,
+        x1: TABLE_WIDTH + 25,
         y1: CENTER_Y,
         x2: TABLE_WIDTH + 50,
         y2: CENTER_Y,
@@ -239,25 +239,25 @@ describe('getDraw', () => {
       expect(result.path.path.L).toEqual({ x: 900, y: CENTER_Y });
       expect(result.path.path.d()).toBe('M 415 28 L 900 28');
       expect(result.line.start.base).toEqual({
-        x1: TABLE_WIDTH + 16,
-        y1: CENTER_Y - 10,
-        x2: TABLE_WIDTH + 16,
-        y2: CENTER_Y + 10,
+        x1: TABLE_WIDTH + 11,
+        y1: CENTER_Y - 7,
+        x2: TABLE_WIDTH + 11,
+        y2: CENTER_Y + 7,
       });
       expect(result.line.start.base2).toEqual({
-        x1: TABLE_WIDTH + 26,
-        y1: CENTER_Y - 10,
-        x2: TABLE_WIDTH + 26,
-        y2: CENTER_Y + 10,
+        x1: TABLE_WIDTH + 18,
+        y1: CENTER_Y - 7,
+        x2: TABLE_WIDTH + 18,
+        y2: CENTER_Y + 7,
       });
       expect(result.line.start.center).toEqual({
-        x1: TABLE_WIDTH + 16,
+        x1: TABLE_WIDTH + 11,
         y1: CENTER_Y,
         x2: TABLE_WIDTH,
         y2: CENTER_Y,
       });
       expect(result.line.start.center2).toEqual({
-        x1: TABLE_WIDTH + 35,
+        x1: TABLE_WIDTH + 25,
         y1: CENTER_Y,
         x2: TABLE_WIDTH,
         y2: CENTER_Y,
@@ -299,13 +299,13 @@ describe('getDraw', () => {
     expect(draw.start).toEqual({ tableId: 'does-not-exist', x: 10, y: 20 });
     // bottom is the default direction, so the path still grows downwards even
     // though the end point sits to the left
-    expect(result.path.line.start).toEqual({ x1: 10, y1: 55, x2: 10, y2: 70 });
+    expect(result.path.line.start).toEqual({ x1: 10, y1: 45, x2: 10, y2: 70 });
     expect(result.path.path.M).toEqual({ x: 10, y: 70 });
     expect(result.path.path.L).toEqual({ x: -900, y: 20 });
-    expect(result.line.start.base).toEqual({ x1: 0, y1: 36, x2: 20, y2: 36 });
+    expect(result.line.start.base).toEqual({ x1: 3, y1: 31, x2: 17, y2: 31 });
     expect(result.line.start.center2).toEqual({
       x1: 10,
-      y1: 55,
+      y1: 45,
       x2: 10,
       y2: 20,
     });

--- a/packages/erd-editor/src/utils/draw-relationship/draw.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/draw.ts
@@ -236,7 +236,7 @@ function getDrawLine(
     line.start.base.y2 += LINE_SIZE;
     line.start.base2.y1 -= LINE_SIZE;
     line.start.base2.y2 += LINE_SIZE;
-    line.start.center2.x1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.start.center2.x1 += change * PATH_LINE_HEIGHT;
   } else if (
     direction === DirectionName.top ||
     direction === DirectionName.bottom
@@ -252,7 +252,7 @@ function getDrawLine(
     line.start.base.x2 += LINE_SIZE;
     line.start.base2.x1 -= LINE_SIZE;
     line.start.base2.x2 += LINE_SIZE;
-    line.start.center2.y1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.start.center2.y1 += change * PATH_LINE_HEIGHT;
   }
 
   return line;

--- a/packages/erd-editor/src/utils/draw-relationship/index.test.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/index.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import {
   CIRCLE_HEIGHT,
+  CIRCLE_RADIUS,
   DirectionName,
   DirectionNameList,
   isDirection,
   LINE_HEIGHT,
   LINE_SIZE,
+  MIN_STUB,
   PATH_END_HEIGHT,
   PATH_HEIGHT,
   PATH_LINE_HEIGHT,
@@ -53,13 +55,34 @@ describe('layout constants', () => {
   });
 
   it('exposes the line drawing metrics', () => {
-    expect(PATH_LINE_HEIGHT).toBe(35);
-    expect(LINE_SIZE).toBe(10);
-    expect(LINE_HEIGHT).toBe(16);
-    expect(CIRCLE_HEIGHT).toBe(26);
+    expect(PATH_LINE_HEIGHT).toBe(25);
+    expect(LINE_SIZE).toBe(7);
+    expect(LINE_HEIGHT).toBe(11);
+    expect(CIRCLE_HEIGHT).toBe(18);
+    expect(CIRCLE_RADIUS).toBe(6);
+  });
+
+  it('centres the ring on the second tick', () => {
+    expect(CIRCLE_HEIGHT).toBe(LINE_SIZE + LINE_HEIGHT);
+  });
+
+  it('starts the guide line where the longest decoration stroke ends', () => {
+    expect(PATH_LINE_HEIGHT).toBe(LINE_HEIGHT + LINE_HEIGHT + 3);
+  });
+
+  it('leaves the ring clear of the tick behind it and the guide line ahead', () => {
+    expect(CIRCLE_HEIGHT - CIRCLE_RADIUS).toBeGreaterThan(LINE_HEIGHT);
+    expect(CIRCLE_HEIGHT + CIRCLE_RADIUS).toBeLessThan(PATH_LINE_HEIGHT);
   });
 
   it('keeps the path line stub shorter than the path end', () => {
     expect(PATH_LINE_HEIGHT).toBeLessThan(PATH_END_HEIGHT);
+  });
+
+  it('clamps a stub clear of the decorations without following them down', () => {
+    expect(MIN_STUB).toBe(36);
+    // The guide line runs from the decorations out to the stub, so a stub
+    // inside them draws it backwards.
+    expect(MIN_STUB).toBeGreaterThan(PATH_LINE_HEIGHT);
   });
 });

--- a/packages/erd-editor/src/utils/draw-relationship/index.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/index.ts
@@ -105,10 +105,26 @@ export const isDirection = arrayHas<string>([
 
 export const PATH_HEIGHT = 30;
 export const PATH_END_HEIGHT = PATH_HEIGHT + 20;
-export const PATH_LINE_HEIGHT = 35;
-export const LINE_SIZE = 10;
-export const LINE_HEIGHT = 16;
-export const CIRCLE_HEIGHT = 26;
+
+/**
+ * The cardinality decoration, measured outward from the anchor.
+ *
+ * The four are one shape and cannot be set independently: the second tick and
+ * the ring share a centre at `LINE_SIZE + LINE_HEIGHT`, the guide line starts
+ * where the longest stroke ends at `LINE_HEIGHT * 2 + 3`, and the ring has to
+ * clear the first tick behind it and the guide line in front of it, which puts
+ * its radius between those two.
+ *
+ * Scaled to 0.7 of what they were, so a decoration reaches 25px out rather than
+ * 35px. `RELATIONSHIP_STROKE_WIDTH` thinned the connector; leaving the notation
+ * at its old size would have made the crow's foot the heaviest thing on the
+ * canvas.
+ */
+export const LINE_SIZE = 7;
+export const LINE_HEIGHT = 11;
+export const CIRCLE_HEIGHT = LINE_SIZE + LINE_HEIGHT;
+export const CIRCLE_RADIUS = 6;
+export const PATH_LINE_HEIGHT = LINE_HEIGHT + LINE_HEIGHT + 3;
 
 /**
  * How far apart the corridors of two relationships leaving the same table side
@@ -127,11 +143,17 @@ export const STUB_STEP = 12;
 export const STUB_CYCLE = 4;
 
 /**
- * The shortest a stub may be clamped to. The cardinality decorations reach
- * `PATH_LINE_HEIGHT` out from the anchor and the guide line is drawn from there
- * to the stub, so a shorter stub draws that line backwards.
+ * The shortest a stub may be clamped to.
+ *
+ * It has to clear `PATH_LINE_HEIGHT`: the cardinality decorations reach that far
+ * out from the anchor and the guide line is drawn from there to the stub, so a
+ * shorter stub draws that line backwards. It is not derived from it. 36 is where
+ * the routing was measured, and letting it follow the decorations down to 26
+ * when they shrank took the medium corpus from 168px of collinear overlap to
+ * 484px — two tables facing each other closer than `2 * MIN_STUB` turn in
+ * earlier, and the routing bench found them sharing a corridor for 316px.
  */
-export const MIN_STUB = PATH_LINE_HEIGHT + 1;
+export const MIN_STUB = 36;
 
 /**
  * The widest gap allowed between two anchors on the same table side.

--- a/packages/erd-editor/src/utils/draw-relationship/nudge.fuzz.test.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/nudge.fuzz.test.ts
@@ -118,7 +118,7 @@ function chainScene(seed: number): Scene {
   return { routes, obstacles: OBSTACLES, endpoints };
 }
 
-/** Total length two connectors run within a stroke width of each other. */
+/** Total length two connectors run within 3px of each other. */
 const bandOverlap = (routes: Scene['routes'], band = 3) => {
   const runs: Array<{
     id: string;

--- a/packages/erd-editor/src/utils/draw-relationship/nudge.test.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/nudge.test.ts
@@ -61,10 +61,15 @@ const selfCrosses = (points: Point[]) => {
 };
 
 /**
- * Total length two connectors run within one stroke width of each other, over
- * every segment drawn — the same question `e2e/bench/geometry.ts` asks of a real
- * scene, and the one the tests below would otherwise only ask of the two or three
+ * Total length two connectors run within 3px of each other, over every segment
+ * drawn — the same question `e2e/bench/geometry.ts` asks of a real scene, and
+ * the one the tests below would otherwise only ask of the two or three
  * coordinates each was written around.
+ *
+ * The band is not `RELATIONSHIP_STROKE_WIDTH`. It is the separation these cases
+ * are written around: the pairs below start 2px and 3px apart, and a band as
+ * narrow as the connector is drawn would score them clear before the pass had
+ * moved anything.
  */
 const bandOverlap = (routes: Record<string, Point[]>, band = 3) => {
   type Run = {
@@ -146,7 +151,7 @@ describe('nudgeRoutes', () => {
     expect(bandOverlap({ a, b })).toBe(0);
   });
 
-  it('separates two channels a stroke width apart', () => {
+  it('separates two channels two pixels apart', () => {
     // The worst pair of the small benchmark corpus: two vertical runs at x = 920
     // and x = 922, which a channel keyed on the rounded coordinate filed apart
     // and never considered.
@@ -173,7 +178,7 @@ describe('nudgeRoutes', () => {
 
   it('spreads a chain of near-coincident channels evenly', () => {
     // 0-3-6 is one bundle even though no two share a coordinate: a reader sees
-    // three lines within a stroke width, not three channels. The lanes are
+    // three lines within one band, not three channels. The lanes are
     // centred on the mean of the three, not on whichever the sort put first.
     const a = line([0, 0], [0, 100], [300, 100], [300, 400]);
     const b = line([10, 0], [10, 103], [310, 103], [310, 400]);
@@ -419,7 +424,7 @@ describe('nudgeRoutes', () => {
 
   it('separates two parallel runs of one connector without folding it', () => {
     // The escape route leaves both anchors on the same axis and comes back, so
-    // its two upright runs can land within a stroke width of each other. The
+    // its two upright runs can land within one band of each other. The
     // lanes are handed out in entry order, which here swaps them — and one of
     // the two ways round walks the connector across itself.
     const u = line(

--- a/packages/erd-editor/src/utils/draw-relationship/nudge.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/nudge.ts
@@ -16,7 +16,7 @@ import {
  * on their own. Measured, not predicted.
  *
  * Segments are collected into a channel by proximity, not by a shared
- * coordinate. The complaint is visual — two connectors within a stroke width
+ * coordinate. The complaint is visual — two connectors within a few pixels
  * read as one line — and the benchmark's worst pair in every corpus was 2px
  * apart: indistinguishable to a reader, yet far enough apart that rounding each
  * coordinate to the pixel filed them under different channels, where nothing
@@ -27,7 +27,7 @@ import {
  * from its anchor.
  */
 
-/** Separation given to routes sharing a channel. Stroke width is 3. */
+/** Separation given to routes sharing a channel. The connector is 2 wide. */
 const NUDGE_GAP = 10;
 
 /**
@@ -35,13 +35,23 @@ const NUDGE_GAP = 10;
  * lanes hold each segment nearer the channel the router chose, so a group whose
  * preferred lanes all run into a table can still be pulled apart rather than
  * give up and stay collinear.
+ *
+ * The floor is 4 rather than the 3 a 2px connector would allow, because the
+ * routing bench says so: `[10, 7, 4, 3]`, `[10, 7, 5, 3]` and `[10, 6, 3]` each
+ * took the medium corpus from 0 to 316px of collinear overlap and cost the large
+ * one 1-10% besides, for 5-6% fewer crossings. Since the first rung that clears
+ * a group wins, a narrower rung is not an extra chance — it lets a group settle
+ * where a wider one would have pushed it somewhere better.
  */
 const NUDGE_GAPS = [NUDGE_GAP, 7, 4];
 
 /**
  * Closer than this and two segments still read as one line, so this is both what
- * the pass sets out to fix and the floor of the ladder above: a pixel clear of
- * the stroke, because touching is legible and drawn on top of each other is not.
+ * the pass sets out to fix and the floor of the ladder above: touching is
+ * legible and drawn on top of each other is not.
+ *
+ * A 2px connector 4px from its neighbour leaves 2px of clear space, where the
+ * 3px one it replaced left 1px. That is slack the ladder above keeps on purpose.
  */
 const MIN_NUDGE_GAP = NUDGE_GAPS[NUDGE_GAPS.length - 1];
 
@@ -56,7 +66,7 @@ const NUDGE_EPSILON = 0.5;
  * out 3.999999999999982 apart for a centre of 126.8333. Measured against the rung
  * itself, the narrowest one can then never clear a group, and the group is
  * abandoned on the coordinate it started on: whether the pass works at all turns
- * on the fraction in a table's position. 3.5px is still clear of the 3px stroke.
+ * on the fraction in a table's position. 3.5px is still clear of the stroke.
  */
 const SEPARATED = MIN_NUDGE_GAP - NUDGE_EPSILON;
 

--- a/packages/erd-editor/src/utils/draw-relationship/pathFinding.test.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/pathFinding.test.ts
@@ -30,8 +30,8 @@ describe('getRelationshipPath', () => {
     });
 
     it('pushes the path guide line out by PATH_LINE_HEIGHT', () => {
-      expect(path.line.start).toEqual({ x1: 135, y1: 50, x2: 150, y2: 50 });
-      expect(path.line.end).toEqual({ x1: 365, y1: 50, x2: 350, y2: 50 });
+      expect(path.line.start).toEqual({ x1: 125, y1: 50, x2: 150, y2: 50 });
+      expect(path.line.end).toEqual({ x1: 375, y1: 50, x2: 350, y2: 50 });
     });
 
     it('draws one straight run when the two anchors line up', () => {
@@ -45,50 +45,50 @@ describe('getRelationshipPath', () => {
 
     it('lays out the start decoration lines horizontally', () => {
       expect(line.line.start.base).toEqual({
-        x1: 116,
-        y1: 40,
-        x2: 116,
-        y2: 60,
+        x1: 111,
+        y1: 43,
+        x2: 111,
+        y2: 57,
       });
       expect(line.line.start.base2).toEqual({
-        x1: 126,
-        y1: 40,
-        x2: 126,
-        y2: 60,
+        x1: 118,
+        y1: 43,
+        x2: 118,
+        y2: 57,
       });
       expect(line.line.start.center).toEqual({
-        x1: 116,
+        x1: 111,
         y1: 50,
         x2: 100,
         y2: 50,
       });
       expect(line.line.start.center2).toEqual({
-        x1: 135,
+        x1: 125,
         y1: 50,
         x2: 100,
         y2: 50,
       });
-      expect(line.startCircle).toEqual({ cx: 126, cy: 50 });
+      expect(line.startCircle).toEqual({ cx: 118, cy: 50 });
     });
 
     it('lays out the end decoration lines horizontally', () => {
-      expect(line.line.end.base).toEqual({ x1: 384, y1: 40, x2: 384, y2: 60 });
-      expect(line.line.end.base2).toEqual({ x1: 374, y1: 40, x2: 374, y2: 60 });
-      expect(line.line.end.left).toEqual({ x1: 384, y1: 50, x2: 400, y2: 60 });
-      expect(line.line.end.right).toEqual({ x1: 384, y1: 50, x2: 400, y2: 40 });
+      expect(line.line.end.base).toEqual({ x1: 389, y1: 43, x2: 389, y2: 57 });
+      expect(line.line.end.base2).toEqual({ x1: 382, y1: 43, x2: 382, y2: 57 });
+      expect(line.line.end.left).toEqual({ x1: 389, y1: 50, x2: 400, y2: 57 });
+      expect(line.line.end.right).toEqual({ x1: 389, y1: 50, x2: 400, y2: 43 });
       expect(line.line.end.center).toEqual({
-        x1: 384,
+        x1: 389,
         y1: 50,
         x2: 400,
         y2: 50,
       });
       expect(line.line.end.center2).toEqual({
-        x1: 365,
+        x1: 375,
         y1: 50,
         x2: 400,
         y2: 50,
       });
-      expect(line.circle).toEqual({ cx: 374, cy: 50 });
+      expect(line.circle).toEqual({ cx: 382, cy: 50 });
     });
   });
 
@@ -103,8 +103,8 @@ describe('getRelationshipPath', () => {
     it('pushes the path end points out on the y axis', () => {
       expect(path.path.M).toEqual({ x: 100, y: 150 });
       expect(path.path.L).toEqual({ x: 300, y: 450 });
-      expect(path.line.start).toEqual({ x1: 100, y1: 135, x2: 100, y2: 150 });
-      expect(path.line.end).toEqual({ x1: 300, y1: 465, x2: 300, y2: 450 });
+      expect(path.line.start).toEqual({ x1: 100, y1: 125, x2: 100, y2: 150 });
+      expect(path.line.end).toEqual({ x1: 300, y1: 475, x2: 300, y2: 450 });
     });
 
     it('turns at right angles on the y axis, with the corners cut', () => {
@@ -136,70 +136,70 @@ describe('getRelationshipPath', () => {
 
     it('lays out the start decoration lines vertically', () => {
       expect(line.line.start.base).toEqual({
-        x1: 90,
-        y1: 116,
-        x2: 110,
-        y2: 116,
+        x1: 93,
+        y1: 111,
+        x2: 107,
+        y2: 111,
       });
       expect(line.line.start.base2).toEqual({
-        x1: 90,
-        y1: 126,
-        x2: 110,
-        y2: 126,
+        x1: 93,
+        y1: 118,
+        x2: 107,
+        y2: 118,
       });
       expect(line.line.start.center).toEqual({
         x1: 100,
-        y1: 116,
+        y1: 111,
         x2: 100,
         y2: 100,
       });
       expect(line.line.start.center2).toEqual({
         x1: 100,
-        y1: 135,
+        y1: 125,
         x2: 100,
         y2: 100,
       });
-      expect(line.startCircle).toEqual({ cx: 100, cy: 126 });
+      expect(line.startCircle).toEqual({ cx: 100, cy: 118 });
     });
 
     it('lays out the end decoration lines vertically', () => {
       expect(line.line.end.base).toEqual({
-        x1: 290,
-        y1: 484,
-        x2: 310,
-        y2: 484,
+        x1: 293,
+        y1: 489,
+        x2: 307,
+        y2: 489,
       });
       expect(line.line.end.base2).toEqual({
-        x1: 290,
-        y1: 474,
-        x2: 310,
-        y2: 474,
+        x1: 293,
+        y1: 482,
+        x2: 307,
+        y2: 482,
       });
       expect(line.line.end.left).toEqual({
         x1: 300,
-        y1: 484,
-        x2: 310,
+        y1: 489,
+        x2: 307,
         y2: 500,
       });
       expect(line.line.end.right).toEqual({
         x1: 300,
-        y1: 484,
-        x2: 290,
+        y1: 489,
+        x2: 293,
         y2: 500,
       });
       expect(line.line.end.center).toEqual({
         x1: 300,
-        y1: 484,
+        y1: 489,
         x2: 300,
         y2: 500,
       });
       expect(line.line.end.center2).toEqual({
         x1: 300,
-        y1: 465,
+        y1: 475,
         x2: 300,
         y2: 500,
       });
-      expect(line.circle).toEqual({ cx: 300, cy: 474 });
+      expect(line.circle).toEqual({ cx: 300, cy: 482 });
     });
   });
 
@@ -240,31 +240,31 @@ describe('getRelationshipPath', () => {
 
     it('mirrors the decoration lines for the inverted directions', () => {
       expect(line.line.start.center).toEqual({
-        x1: 484,
+        x1: 489,
         y1: 200,
         x2: 500,
         y2: 200,
       });
       expect(line.line.start.center2).toEqual({
-        x1: 465,
+        x1: 475,
         y1: 200,
         x2: 500,
         y2: 200,
       });
       expect(line.line.end.left).toEqual({
-        x1: 116,
+        x1: 111,
         y1: 260,
         x2: 100,
-        y2: 270,
+        y2: 267,
       });
       expect(line.line.end.right).toEqual({
-        x1: 116,
+        x1: 111,
         y1: 260,
         x2: 100,
-        y2: 250,
+        y2: 253,
       });
-      expect(line.startCircle).toEqual({ cx: 474, cy: 200 });
-      expect(line.circle).toEqual({ cx: 126, cy: 260 });
+      expect(line.startCircle).toEqual({ cx: 482, cy: 200 });
+      expect(line.circle).toEqual({ cx: 118, cy: 260 });
     });
   });
 
@@ -289,37 +289,37 @@ describe('getRelationshipPath', () => {
 
     it('flips the end decoration lines downwards', () => {
       expect(line.line.end.base).toEqual({
-        x1: 190,
-        y1: 116,
-        x2: 210,
-        y2: 116,
+        x1: 193,
+        y1: 111,
+        x2: 207,
+        y2: 111,
       });
       expect(line.line.end.base2).toEqual({
-        x1: 190,
-        y1: 126,
-        x2: 210,
-        y2: 126,
+        x1: 193,
+        y1: 118,
+        x2: 207,
+        y2: 118,
       });
       expect(line.line.end.left).toEqual({
         x1: 200,
-        y1: 116,
-        x2: 210,
+        y1: 111,
+        x2: 207,
         y2: 100,
       });
       expect(line.line.end.right).toEqual({
         x1: 200,
-        y1: 116,
-        x2: 190,
+        y1: 111,
+        x2: 193,
         y2: 100,
       });
       expect(line.line.end.center2).toEqual({
         x1: 200,
-        y1: 135,
+        y1: 125,
         x2: 200,
         y2: 100,
       });
-      expect(line.startCircle).toEqual({ cx: 200, cy: 374 });
-      expect(line.circle).toEqual({ cx: 200, cy: 126 });
+      expect(line.startCircle).toEqual({ cx: 200, cy: 382 });
+      expect(line.circle).toEqual({ cx: 200, cy: 118 });
     });
   });
 
@@ -343,29 +343,29 @@ describe('getRelationshipPath', () => {
     });
 
     it('still lays out both decoration ends', () => {
-      expect(path.line.start).toEqual({ x1: 98, y1: -35, x2: 98, y2: -50 });
-      expect(path.line.end).toEqual({ x1: 153, y1: 20, x2: 168, y2: 20 });
+      expect(path.line.start).toEqual({ x1: 98, y1: -25, x2: 98, y2: -50 });
+      expect(path.line.end).toEqual({ x1: 143, y1: 20, x2: 168, y2: 20 });
       expect(line.line.start.base).toEqual({
-        x1: 88,
-        y1: -16,
-        x2: 108,
-        y2: -16,
+        x1: 91,
+        y1: -11,
+        x2: 105,
+        y2: -11,
       });
       expect(line.line.start.center2).toEqual({
         x1: 98,
-        y1: -35,
+        y1: -25,
         x2: 98,
         y2: 0,
       });
-      expect(line.line.end.base).toEqual({ x1: 134, y1: 10, x2: 134, y2: 30 });
+      expect(line.line.end.base).toEqual({ x1: 129, y1: 13, x2: 129, y2: 27 });
       expect(line.line.end.center2).toEqual({
-        x1: 153,
+        x1: 143,
         y1: 20,
         x2: 118,
         y2: 20,
       });
-      expect(line.startCircle).toEqual({ cx: 98, cy: -26 });
-      expect(line.circle).toEqual({ cx: 144, cy: 20 });
+      expect(line.startCircle).toEqual({ cx: 98, cy: -18 });
+      expect(line.circle).toEqual({ cx: 136, cy: 20 });
     });
   });
 

--- a/packages/erd-editor/src/utils/draw-relationship/pathFinding.ts
+++ b/packages/erd-editor/src/utils/draw-relationship/pathFinding.ts
@@ -232,7 +232,7 @@ function getLine(
     line.start.base.y2 += LINE_SIZE;
     line.start.base2.y1 -= LINE_SIZE;
     line.start.base2.y2 += LINE_SIZE;
-    line.start.center2.x1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.start.center2.x1 += change * PATH_LINE_HEIGHT;
 
     startCircle.cx += change * CIRCLE_HEIGHT;
   } else if (
@@ -250,7 +250,7 @@ function getLine(
     line.start.base.x2 += LINE_SIZE;
     line.start.base2.x1 -= LINE_SIZE;
     line.start.base2.x2 += LINE_SIZE;
-    line.start.center2.y1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.start.center2.y1 += change * PATH_LINE_HEIGHT;
 
     startCircle.cy += change * CIRCLE_HEIGHT;
   }
@@ -272,7 +272,7 @@ function getLine(
     line.end.base2.y2 += LINE_SIZE;
     line.end.left.y2 += LINE_SIZE;
     line.end.right.y2 -= LINE_SIZE;
-    line.end.center2.x1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.end.center2.x1 += change * PATH_LINE_HEIGHT;
 
     circle.cx += change * CIRCLE_HEIGHT;
   } else if (
@@ -294,7 +294,7 @@ function getLine(
     line.end.base2.x2 += LINE_SIZE;
     line.end.left.x2 += LINE_SIZE;
     line.end.right.x2 -= LINE_SIZE;
-    line.end.center2.y1 += change * (LINE_HEIGHT + LINE_HEIGHT + 3);
+    line.end.center2.y1 += change * PATH_LINE_HEIGHT;
 
     circle.cy += change * CIRCLE_HEIGHT;
   }


### PR DESCRIPTION
Closes #365.

Connectors were drawn at 3 and their cardinality symbols reached 35px out from
the anchor, which on a busy diagram reads as a mass of strokes rather than as
connections. The stroke is **2** now and the symbols are scaled to **0.7**,
reaching 25px.

| | before | after |
| --- | --- | --- |
| stroke | 3 | 2 |
| `LINE_SIZE` / `LINE_HEIGHT` | 10 / 16 | 7 / 11 |
| symbol reach | 35px | 25px |
| ring radius | 8 | 6 |

2 rather than 1.5 so the stroke lands on pixel boundaries instead of spreading
across two rows at partial alpha on a 1x display.

## The hover target

A pointer finds an SVG path along its painted stroke, so thinning the connector
thins the target for hovering it or opening its context menu — and a missed
right-click is silent, falling through to the generic canvas menu rather than
doing nothing.

Each group carries a transparent `path.hit-area` 8px wide now, running from one
cardinality symbol to the other as a single element: the guide lines start and
end where the route does, so all three fit in one path rather than one band per
segment. It is solid where the route is dashed, because a dash gap is unpainted
and therefore not a target either. `NUDGE_GAP` is 10, so the band stays clear of
the neighbouring corridor except where the router fell back to a narrower lane.

## Routing did not move

`MIN_STUB` was `PATH_LINE_HEIGHT + 1`, so shrinking the symbols pulled it from
36 to 26 — and the routing bench caught it: the medium corpus went from 168px of
collinear overlap to 484px, because two tables facing each other closer than
twice the stub turn in earlier and share a corridor. Pinned at 36 (the
constraint is that it clears the decorations, not that it is derived from them),
the bench reproduces every quality figure exactly: segments, both crossing
counts, node crossings, collinear px and total length.

## The bench's own band was stale

`collinear px` is defined as how far two connectors run within one stroke width
of each other, but the band was a literal 3. It reads from
`RELATIONSHIP_STROKE_WIDTH` now.

That mattered: a band wider than the stroke puts a rung of `NUDGE_GAPS` exactly
on its boundary, where floating point drops it inside. Measured at 3 against a
2px connector, adding a 3px rung looked like a **+188%** collinear regression;
at the corrected band its real cost is 0 → 316px on medium.

Corrected, the same routing scores **0 / 0 / 2721** where it scored
0 / 168 / 2943 before — thinning the connector cleared the medium corpus on its
own, and the wider band had been counting pairs a reader can now separate.
Figures recorded in `e2e/bench/README.md` are marked as measured at 3.

`NUDGE_GAPS` keeps its floor of 4 rather than the 3 a 2px connector would allow.
`[10, 7, 4, 3]`, `[10, 7, 5, 3]` and `[10, 6, 3]` each took medium from 0 to
316px and cost large 1-10% besides, for 5-6% fewer crossings — since the first
rung that clears a group wins, a narrower rung is not an extra chance, it lets a
group settle where a wider one would have pushed it somewhere better.

## Verification

- `pnpm check`, `pnpm test` (3851 in `erd-editor`), `pnpm build`, `e2e:typecheck`
- `pnpm --filter @dineug/erd-editor e2e` — 52 passed
- routing bench, before and after, against a baseline captured on `main`
- `screenshot.bench.ts` before/after on all three corpora, read by eye

New coverage: the hit band's width, paint, `pointer-events` and its span from one
symbol to the other; the stroke width of every one of the seven cardinality
shapes rather than one; the ring start branch, which no test reached; the
minimap's 12; and `CanvasSvg`'s default, which read a decoration and so passed at
any value.

Not done here — `NUDGE_GAPS` was tuned against a 3px stroke and could be narrowed
if the greedy first-rung-wins choice is revisited, and PNG export bakes in the
exporting machine's `devicePixelRatio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
