### PR TITLE
feat: Support Go as a code generation target

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To try it in an IDE, create an empty file with a `.erd.json` extension and open 
 - **SQL DDL import** — point it at a `.sql` dump and get a diagram; the parser skips what it
   does not recognize, so an awkward dump imports partially rather than failing outright
 - **SQL DDL export** — Databricks, MariaDB, MSSQL, MySQL, Oracle, PostgreSQL, SQLite
-- **Code generation** — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala
+- **Code generation** — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala, Go
 - **Visualization** — a force-directed view of how the tables actually relate
 - **Export** — `.erd.json`, `.sql`, `.png`
 - **Quick search**, **undo / redo**, keyboard shortcuts, and a theme builder

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -98,9 +98,9 @@
           ]
         },
         "language": {
-          "description": "bit value (GraphQL: 1) | (csharp: 2) | (Java: 4) | (Kotlin: 8) | (TypeScript: 16) | (JPA: 32) | (Scala: 64)",
+          "description": "bit value (GraphQL: 1) | (csharp: 2) | (Java: 4) | (Kotlin: 8) | (TypeScript: 16) | (JPA: 32) | (Scala: 64) | (Go: 128)",
           "type": "integer",
-          "enum": [1, 2, 4, 8, 16, 32, 64]
+          "enum": [1, 2, 4, 8, 16, 32, 64, 128]
         },
         "tableNameCase": {
           "description": "bit value (none: 1) | (camelCase: 2) | (pascalCase: 4) | (snakeCase: 8)",

--- a/packages/erd-editor-schema/src/convert/index.test.ts
+++ b/packages/erd-editor-schema/src/convert/index.test.ts
@@ -260,6 +260,15 @@ describe('convert barrel', () => {
       expect(result.settings.database).toBe(SchemaV3Constants.Database.MySQL);
     });
 
+    it('loses the Go language because v2 has no such language', () => {
+      const source = createSchemaV3();
+      source.settings.language = SchemaV3Constants.Language.Go;
+      const result = v2ToV3(v3ToV2(source));
+
+      expect(result.settings.language).not.toBe(source.settings.language);
+      expect(result.settings.language).toBe(SchemaV3Constants.Language.GraphQL);
+    });
+
     it('preserves the document ids of tables, memos and relationships', () => {
       const source = createSchemaV3();
       const result = v2ToV3(v3ToV2(source));

--- a/packages/erd-editor-schema/src/convert/v3ToV2.test.ts
+++ b/packages/erd-editor-schema/src/convert/v3ToV2.test.ts
@@ -309,6 +309,13 @@ describe('v3ToV2', () => {
       expect(v3ToV2(schemaV3).canvas.language).toBe('GraphQL');
     });
 
+    it('drops the Go language because v2 has no Go entry', () => {
+      const schemaV3 = createSchemaV3();
+      schemaV3.settings.language = Language.Go;
+
+      expect(v3ToV2(schemaV3).canvas.language).toBe('GraphQL');
+    });
+
     it('drops the Databricks database because "Databricks" is not a v2 database name', () => {
       const schemaV3 = createSchemaV3();
       schemaV3.settings.database = Database.Databricks;

--- a/packages/erd-editor-schema/src/v3/parser/settings.test.ts
+++ b/packages/erd-editor-schema/src/v3/parser/settings.test.ts
@@ -219,6 +219,12 @@ describe('createAndMergeSettings', () => {
       ).toBe(Database.Databricks);
     });
 
+    it('keeps the Go language', () => {
+      expect(createAndMergeSettings({ language: Language.Go }).language).toBe(
+        Language.Go
+      );
+    });
+
     it('ignores numbers outside the enum lists', () => {
       const settings = createAndMergeSettings({
         database: 999,

--- a/packages/erd-editor-schema/src/v3/schema/settings.test.ts
+++ b/packages/erd-editor-schema/src/v3/schema/settings.test.ts
@@ -150,8 +150,9 @@ describe('v3/schema/settings', () => {
         TypeScript: 16,
         JPA: 32,
         Scala: 64,
+        Go: 128,
       });
-      expect(LanguageList).toEqual([1, 2, 4, 8, 16, 32, 64]);
+      expect(LanguageList).toEqual([1, 2, 4, 8, 16, 32, 64, 128]);
       expect(Object.values(Language).every(isPowerOfTwo)).toBe(true);
     });
   });

--- a/packages/erd-editor-schema/src/v3/schema/settings.ts
+++ b/packages/erd-editor-schema/src/v3/schema/settings.ts
@@ -75,6 +75,7 @@ export const Language = {
   TypeScript: /* */ 0b0000000000000000000000000010000,
   JPA: /*        */ 0b0000000000000000000000000100000,
   Scala: /*      */ 0b0000000000000000000000001000000,
+  Go: /*         */ 0b0000000000000000000000010000000,
 } as const;
 export const LanguageList: ReadonlyArray<number> = Object.values(Language);
 

--- a/packages/erd-editor-shiki-worker/README.md
+++ b/packages/erd-editor-shiki-worker/README.md
@@ -52,7 +52,7 @@ puts the whole bundle in your entry chunk whether or not a code panel is ever op
 
 | | |
 | --- | --- |
-| Languages | SQL, TypeScript, GraphQL, C#, Java, Kotlin, Scala |
+| Languages | SQL, TypeScript, GraphQL, C#, Java, Kotlin, Scala, Go |
 | Themes | `github-dark`, `github-light`, picked from the editor's light / dark appearance |
 
 Those are exactly the languages the editor's own panels emit — the SQL export and the seven

--- a/packages/erd-editor-shiki-worker/src/services/shikiService.ts
+++ b/packages/erd-editor-shiki-worker/src/services/shikiService.ts
@@ -2,6 +2,7 @@ import { getHighlighter, setWasm, toShikiTheme } from 'shiki';
 // @ts-ignore
 import wasmUrl from 'shiki/dist/onig.wasm?url';
 import csharp from 'shiki/languages/csharp.tmLanguage.json';
+import go from 'shiki/languages/go.tmLanguage.json';
 import graphql from 'shiki/languages/graphql.tmLanguage.json';
 import java from 'shiki/languages/java.tmLanguage.json';
 import kotlin from 'shiki/languages/kotlin.tmLanguage.json';
@@ -63,6 +64,13 @@ const languages: Array<any> = [
     displayName: 'Scala',
     grammar: scala,
   },
+  {
+    id: 'go',
+    scopeName: 'source.go',
+    displayName: 'Go',
+    aliases: ['golang'],
+    grammar: go,
+  },
 ];
 
 function getThemeKey(theme?: string): 'dark' | 'light' {
@@ -96,7 +104,8 @@ export class ShikiService {
         | 'csharp'
         | 'java'
         | 'kotlin'
-        | 'scala';
+        | 'scala'
+        | 'go';
       theme?: 'dark' | 'light';
     }
   ): Promise<string> {

--- a/packages/erd-editor/AGENTS.md
+++ b/packages/erd-editor/AGENTS.md
@@ -26,7 +26,7 @@ store whose actions carry a Lamport clock version and merge through the LWW regi
 | --- | --- |
 | `src/engine/` | `store` / `rx-store` / `shared-store` (collaboration) / `replication-store` (headless), `clock`, `history`, `tag`, plus `modules/` (eight state modules) and `rx-operators/` |
 | `src/components/` | r-html FCs — `erd/` (canvas, minimap, context menus), `primitives/` (design system), and the `toolbar` / `schema-sql` / `generator-code` / `visualization` / `settings` / `theme-builder` / `quick-search` panels |
-| `src/utils/` | `schema-sql/` (seven DDL vendors), `generator-code/` (seven languages), `schema-sql-parser/` (SQL import), `draw-relationship/`, `collection/`, `file/`, `keyboard-shortcut/`, `rx-operators/` |
+| `src/utils/` | `schema-sql/` (seven DDL vendors), `generator-code/` (eight languages), `schema-sql-parser/` (SQL import), `draw-relationship/`, `collection/`, `file/`, `keyboard-shortcut/`, `rx-operators/` |
 | `src/services/` | `schema-gc/` — orphan collection in a dedicated and a shared worker over comlink — plus `shikiService.ts` |
 | `src/themes/`, `src/styles/` | Theme tokens and the radix palette; global style fragments (reset, typography, fonts, scrollbar). `src/__test-utils__/` holds vitest-only mount helpers, excluded from the dts build and from coverage |
 | `e2e/` | Playwright — `fixture/` (deterministic mount page), `support/` (page object, seeds), `specs/` (six specs), `bench/` (routing benchmark, own config, never in CI), `README.md` |

--- a/packages/erd-editor/README.md
+++ b/packages/erd-editor/README.md
@@ -18,7 +18,7 @@ and the [IntelliJ plugin](https://plugins.jetbrains.com/plugin/23594-erd-editor)
   (zero-one, zero-N, one-only, one-N)
 - SQL DDL import, and export for Databricks, MariaDB, MSSQL, MySQL, Oracle,
   PostgreSQL and SQLite
-- Code generation — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala
+- Code generation — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala, Go
 - Export — `.erd.json`, `.sql`, `.png`
 - Force-directed visualization of table relationships
 - Quick search, undo / redo, remappable keyboard shortcuts, and a built-in theme builder

--- a/packages/erd-editor/src/components/generator-code/generator-code-context-menu/GeneratorCodeContextMenu.test.ts
+++ b/packages/erd-editor/src/components/generator-code/generator-code-context-menu/GeneratorCodeContextMenu.test.ts
@@ -127,6 +127,7 @@ describe('GeneratorCodeContextMenu', () => {
       'TypeScript',
       'JPA',
       'Scala',
+      'Go',
     ]);
     expect(checkedNameOf(submenu)).toEqual(['GraphQL']);
   });

--- a/packages/erd-editor/src/components/generator-code/generator-code-context-menu/menus/languageMenus.test.ts
+++ b/packages/erd-editor/src/components/generator-code/generator-code-context-menu/menus/languageMenus.test.ts
@@ -18,6 +18,7 @@ describe('languageMenus', () => {
       { name: 'TypeScript', value: Language.TypeScript },
       { name: 'JPA', value: Language.JPA },
       { name: 'Scala', value: Language.Scala },
+      { name: 'Go', value: Language.Go },
     ]);
   });
 
@@ -34,6 +35,7 @@ describe('languageMenus', () => {
       'TypeScript',
       'JPA',
       'Scala',
+      'Go',
     ]);
     created.forEach(menu => expect(typeof menu.onClick).toBe('function'));
   });

--- a/packages/erd-editor/src/components/generator-code/generator-code-context-menu/menus/languageMenus.ts
+++ b/packages/erd-editor/src/components/generator-code/generator-code-context-menu/menus/languageMenus.ts
@@ -36,6 +36,10 @@ export const menus: Menu[] = [
     name: 'Scala',
     value: Language.Scala,
   },
+  {
+    name: 'Go',
+    value: Language.Go,
+  },
 ];
 
 export function createLanguageMenus({ store }: AppContext) {

--- a/packages/erd-editor/src/constants/language.test.ts
+++ b/packages/erd-editor/src/constants/language.test.ts
@@ -13,6 +13,7 @@ describe('LanguageToLangMap', () => {
       [Language.TypeScript]: 'typescript',
       [Language.JPA]: 'java',
       [Language.Scala]: 'scala',
+      [Language.Go]: 'go',
     });
   });
 

--- a/packages/erd-editor/src/constants/language.ts
+++ b/packages/erd-editor/src/constants/language.ts
@@ -7,6 +7,7 @@ import { Language } from '@/constants/schema';
  */
 export type Lang =
   | 'csharp'
+  | 'go'
   | 'graphql'
   | 'java'
   | 'kotlin'
@@ -21,4 +22,5 @@ export const LanguageToLangMap: Record<number, Lang> = {
   [Language.Kotlin]: 'kotlin',
   [Language.Scala]: 'scala',
   [Language.JPA]: 'java',
+  [Language.Go]: 'go',
 };

--- a/packages/erd-editor/src/services/shikiService.ts
+++ b/packages/erd-editor/src/services/shikiService.ts
@@ -15,7 +15,8 @@ export type ShikiService = {
         | 'csharp'
         | 'java'
         | 'kotlin'
-        | 'scala';
+        | 'scala'
+        | 'go';
       theme?: 'dark' | 'light';
     }
   ): Promise<string>;

--- a/packages/erd-editor/src/utils/generator-code/go.test.ts
+++ b/packages/erd-editor/src/utils/generator-code/go.test.ts
@@ -1,0 +1,378 @@
+import { schemaV3Parser } from '@dineug/erd-editor-schema';
+import { describe, expect, it } from 'vite-plus/test';
+
+import { ColumnOption, Database, NameCase } from '@/constants/schema';
+import { RootState } from '@/engine/state';
+import { Table } from '@/internal-types';
+import { createTable } from '@/utils/collection/table.entity';
+import { createColumn } from '@/utils/collection/tableColumn.entity';
+import { createCode, formatTable } from '@/utils/generator-code/go';
+
+type ColumnInput = {
+  name: string;
+  dataType?: string;
+  comment?: string;
+  options?: number;
+};
+
+type TableInput = {
+  id: string;
+  name: string;
+  comment?: string;
+  columns?: ColumnInput[];
+};
+
+function createState(): RootState {
+  return {
+    ...schemaV3Parser({}),
+    editor: {} as any,
+    lww: {},
+  } as RootState;
+}
+
+function addTable(
+  state: RootState,
+  { id, name, comment = '', columns = [] }: TableInput
+): Table {
+  const entities = columns.map((column, index) =>
+    createColumn({
+      id: `${id}-c${index}`,
+      tableId: id,
+      name: column.name,
+      dataType: column.dataType ?? '',
+      comment: column.comment ?? '',
+      options: column.options ?? 0,
+    })
+  );
+  const table = createTable({
+    id,
+    name,
+    comment,
+    columnIds: entities.map(column => column.id),
+  });
+
+  state.collections.tableEntities[table.id] = table;
+  entities.forEach(column => {
+    state.collections.tableColumnEntities[column.id] = column;
+  });
+  state.doc.tableIds.push(table.id);
+
+  return table;
+}
+
+describe('generator-code/go', () => {
+  it('returns an empty string when there is no table', () => {
+    expect(createCode(createState())).toBe('');
+  });
+
+  it('emits structs sorted by name with comments and pointer nullables', () => {
+    const state = createState();
+
+    addTable(state, {
+      id: 't-users',
+      name: 'users',
+      comment: 'user table',
+      columns: [
+        {
+          name: 'id',
+          dataType: 'INT',
+          comment: 'user id',
+          options: ColumnOption.primaryKey | ColumnOption.notNull,
+        },
+        { name: 'nick_name', dataType: 'VARCHAR(50)' },
+      ],
+    });
+    addTable(state, {
+      id: 't-posts',
+      name: 'posts',
+      columns: [
+        { name: 'id', dataType: 'BIGINT', options: ColumnOption.notNull },
+      ],
+    });
+
+    expect(createCode(state)).toBe(
+      [
+        '',
+        'type Posts struct {',
+        '\tId int64 `json:"id"`',
+        '}',
+        '',
+        '// user table',
+        'type Users struct {',
+        '\t// user id',
+        '\tId       int32   `json:"id"`',
+        '\tNickName *string `json:"nick_name"`',
+        '}',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('maps every primitive type to a Go type', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-types',
+      name: 'types',
+      columns: [
+        { name: 'intCol', dataType: 'INT', options: ColumnOption.notNull },
+        { name: 'longCol', dataType: 'BIGINT', options: ColumnOption.notNull },
+        { name: 'floatCol', dataType: 'FLOAT', options: ColumnOption.notNull },
+        {
+          name: 'doubleCol',
+          dataType: 'DOUBLE',
+          options: ColumnOption.notNull,
+        },
+        {
+          name: 'decimalCol',
+          dataType: 'DECIMAL(10, 2)',
+          options: ColumnOption.notNull,
+        },
+        {
+          name: 'booleanCol',
+          dataType: 'BOOLEAN',
+          options: ColumnOption.notNull,
+        },
+        {
+          name: 'stringCol',
+          dataType: 'VARCHAR(10)',
+          options: ColumnOption.notNull,
+        },
+        { name: 'lobCol', dataType: 'TEXT', options: ColumnOption.notNull },
+        { name: 'dateCol', dataType: 'DATE', options: ColumnOption.notNull },
+        { name: 'timeCol', dataType: 'TIME', options: ColumnOption.notNull },
+        {
+          name: 'unknownCol',
+          dataType: 'NOT_A_TYPE',
+          options: ColumnOption.notNull,
+        },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Types struct {',
+      '\tIntCol     int32           `json:"intCol"`',
+      '\tLongCol    int64           `json:"longCol"`',
+      '\tFloatCol   float32         `json:"floatCol"`',
+      '\tDoubleCol  float64         `json:"doubleCol"`',
+      '\tDecimalCol decimal.Decimal `json:"decimalCol"`',
+      '\tBooleanCol bool            `json:"booleanCol"`',
+      '\tStringCol  string          `json:"stringCol"`',
+      '\tLobCol     string          `json:"lobCol"`',
+      '\tDateCol    time.Time       `json:"dateCol"`',
+      '\tTimeCol    time.Time       `json:"timeCol"`',
+      '\tUnknownCol string          `json:"unknownCol"`',
+      '}',
+    ]);
+  });
+
+  it('maps the dateTime primitive type to time.Time', () => {
+    const state = createState();
+    state.settings.database = Database.Oracle;
+    const table = addTable(state, {
+      id: 't-ts',
+      name: 'ts',
+      columns: [
+        {
+          name: 'created_at',
+          dataType: 'TIMESTAMP',
+          options: ColumnOption.notNull,
+        },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Ts struct {',
+      '\tCreatedAt time.Time `json:"created_at"`',
+      '}',
+    ]);
+  });
+
+  it('points at the type for columns without the not null option', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-nullable',
+      name: 'nullable',
+      columns: [
+        { name: 'intCol', dataType: 'INT', options: ColumnOption.primaryKey },
+        { name: 'boolCol', dataType: 'BOOLEAN', comment: 'a flag' },
+        { name: 'amount', dataType: 'DECIMAL(10, 2)' },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Nullable struct {',
+      '\tIntCol *int32 `json:"intCol"`',
+      '\t// a flag',
+      '\tBoolCol *bool            `json:"boolCol"`',
+      '\tAmount  *decimal.Decimal `json:"amount"`',
+      '}',
+    ]);
+  });
+
+  it('restarts the column alignment at a comment, the way gofmt does', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-runs',
+      name: 'runs',
+      columns: [
+        { name: 'id', dataType: 'INT', options: ColumnOption.notNull },
+        {
+          name: 'name',
+          dataType: 'VARCHAR(10)',
+          options: ColumnOption.notNull,
+        },
+        {
+          name: 'settled_amount',
+          dataType: 'DECIMAL(19, 4)',
+          comment: 'in the account currency',
+          options: ColumnOption.notNull,
+        },
+        { name: 'memo', dataType: 'TEXT', options: ColumnOption.notNull },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Runs struct {',
+      '\tId   int32  `json:"id"`',
+      '\tName string `json:"name"`',
+      '\t// in the account currency',
+      '\tSettledAmount decimal.Decimal `json:"settled_amount"`',
+      '\tMemo          string          `json:"memo"`',
+      '}',
+    ]);
+  });
+
+  it('exports the struct and its fields whatever the name case setting is', () => {
+    const state = createState();
+    state.settings.tableNameCase = NameCase.snakeCase;
+    state.settings.columnNameCase = NameCase.camelCase;
+    const table = addTable(state, {
+      id: 't-user-profile',
+      name: 'UserProfile',
+      columns: [
+        { name: 'user_id', dataType: 'INT', options: ColumnOption.notNull },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type User_profile struct {',
+      '\tUserId int32 `json:"user_id"`',
+      '}',
+    ]);
+  });
+
+  it('keeps the tag on the column name the database spells, not the cased one', () => {
+    const state = createState();
+    state.settings.columnNameCase = NameCase.pascalCase;
+    const table = addTable(state, {
+      id: 't-tags',
+      name: 'tags',
+      columns: [
+        {
+          name: 'created_at',
+          dataType: 'TIMESTAMP',
+          options: ColumnOption.notNull,
+        },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Tags struct {',
+      '\tCreatedAt time.Time `json:"created_at"`',
+      '}',
+    ]);
+  });
+
+  it('escapes a quote or a backslash so the tag reads back as the column name', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-quoted',
+      name: 'quoted',
+      columns: [
+        { name: 'say"hi', dataType: 'INT', options: ColumnOption.notNull },
+        { name: 'back\\slash', dataType: 'INT', options: ColumnOption.notNull },
+        { name: 'plain', dataType: 'INT', options: ColumnOption.notNull },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Quoted struct {',
+      '\tSayHi     int32 `json:"say\\"hi"`',
+      '\tBackSlash int32 `json:"back\\\\slash"`',
+      '\tPlain     int32 `json:"plain"`',
+      '}',
+    ]);
+  });
+
+  it('falls back to an interpreted tag literal for a name holding a backtick', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-backtick',
+      name: 'backtick',
+      columns: [
+        { name: 'we`ird', dataType: 'INT', options: ColumnOption.notNull },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual([
+      'type Backtick struct {',
+      '\tWeIrd int32 "json:\\"we`ird\\""',
+      '}',
+    ]);
+  });
+
+  it('emits an empty struct body for a table without columns', () => {
+    const state = createState();
+    const table = addTable(state, { id: 't-empty', name: 'empty' });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    expect(buffer).toEqual(['type Empty struct {', '}']);
+  });
+
+  it('leaves no trailing whitespace on a field line', () => {
+    const state = createState();
+    const table = addTable(state, {
+      id: 't-widths',
+      name: 'widths',
+      columns: [
+        { name: 'a', dataType: 'INT', options: ColumnOption.notNull },
+        {
+          name: 'bbbbbbbb',
+          dataType: 'DECIMAL(10, 2)',
+          options: ColumnOption.notNull,
+        },
+      ],
+    });
+    const buffer: string[] = [];
+
+    formatTable(state, { buffer, table });
+
+    buffer.forEach(line => expect(line).toBe(line.trimEnd()));
+  });
+});

--- a/packages/erd-editor/src/utils/generator-code/go.ts
+++ b/packages/erd-editor/src/utils/generator-code/go.ts
@@ -1,0 +1,139 @@
+import { query } from '@dineug/erd-editor-schema';
+import { upperFirst } from 'es-toolkit';
+
+import { ColumnOption } from '@/constants/schema';
+import { PrimitiveTypeMap } from '@/constants/sql/dataType';
+import { RootState } from '@/engine/state';
+import { Column } from '@/internal-types';
+import { bHas } from '@/utils/bit';
+import { orderByNameASC } from '@/utils/schema-sql/utils';
+
+import { FormatTableOptions, getNameCase, getPrimitiveType } from './utils';
+
+const convertTypeMap: PrimitiveTypeMap = {
+  int: 'int32',
+  long: 'int64',
+  float: 'float32',
+  double: 'float64',
+  decimal: 'decimal.Decimal',
+  boolean: 'bool',
+  string: 'string',
+  lob: 'string',
+  date: 'time.Time',
+  dateTime: 'time.Time',
+  time: 'time.Time',
+};
+
+type Field = {
+  name: string;
+  type: string;
+  tag: string;
+  comment: string;
+};
+
+export function createCode(state: RootState): string {
+  const {
+    doc: { tableIds },
+    collections,
+  } = state;
+  const stringBuffer: string[] = [''];
+  const tables = query(collections)
+    .collection('tableEntities')
+    .selectByIds(tableIds)
+    .sort(orderByNameASC);
+
+  tables.forEach(table => {
+    formatTable(state, {
+      buffer: stringBuffer,
+      table,
+    });
+    stringBuffer.push('');
+  });
+
+  return stringBuffer.join('\n');
+}
+
+export function formatTable(
+  state: RootState,
+  { buffer, table }: FormatTableOptions
+) {
+  const {
+    settings: { tableNameCase },
+    collections,
+  } = state;
+  const structName = exported(getNameCase(table.name, tableNameCase));
+
+  if (table.comment.trim() !== '') {
+    buffer.push(`// ${table.comment}`);
+  }
+  buffer.push(`type ${structName} struct {`);
+
+  const fields = query(collections)
+    .collection('tableColumnEntities')
+    .selectByIds(table.columnIds)
+    .map(column => createField(state, column));
+
+  alignmentRunsOf(fields).forEach(run => {
+    const nameWidth = Math.max(...run.map(field => field.name.length));
+    const typeWidth = Math.max(...run.map(field => field.type.length));
+
+    run.forEach(field => {
+      if (field.comment !== '') {
+        buffer.push(`\t// ${field.comment}`);
+      }
+      buffer.push(
+        `\t${field.name.padEnd(nameWidth)} ${field.type.padEnd(typeWidth)} ${
+          field.tag
+        }`
+      );
+    });
+  });
+
+  buffer.push(`}`);
+}
+
+// gofmt's tabwriter ends a column block at the first line that is not a field,
+// and a comment on its own line is one.
+function alignmentRunsOf(fields: Field[]): Field[][] {
+  const runs: Field[][] = [];
+
+  fields.forEach(field => {
+    if (field.comment !== '' || runs.length === 0) {
+      runs.push([]);
+    }
+    runs[runs.length - 1].push(field);
+  });
+
+  return runs;
+}
+
+function createField(
+  { settings: { columnNameCase, database } }: RootState,
+  column: Column
+): Field {
+  const primitiveType = getPrimitiveType(column.dataType, database);
+  const type = convertTypeMap[primitiveType];
+
+  return {
+    name: exported(getNameCase(column.name, columnNameCase)),
+    type: bHas(column.options, ColumnOption.notNull) ? type : `*${type}`,
+    tag: structTag(column.name),
+    comment: column.comment.trim(),
+  };
+}
+
+// reflect.StructTag unquotes the value, and the raw-string form cannot carry a
+// backtick -- a column named with one falls back to the interpreted form.
+function structTag(columnName: string): string {
+  const tag = `json:"${escaped(columnName)}"`;
+
+  return tag.includes('`') ? `"${escaped(tag)}"` : `\`${tag}\``;
+}
+
+function escaped(value: string): string {
+  return value.replace(/["\\]/g, '\\$&');
+}
+
+function exported(name: string): string {
+  return upperFirst(name);
+}

--- a/packages/erd-editor/src/utils/generator-code/index.test.ts
+++ b/packages/erd-editor/src/utils/generator-code/index.test.ts
@@ -92,6 +92,17 @@ const expectedByLanguage: Array<[string, number, string[]]> = [
     Language.Scala,
     ['', '@Data', 'case class User(', ' createdAt: Int', ')', ''],
   ],
+  [
+    'Go',
+    Language.Go,
+    [
+      '',
+      'type User struct {',
+      '\tCreatedAt int32 `json:"created_at"`',
+      '}',
+      '',
+    ],
+  ],
 ];
 
 describe('generator-code/index', () => {

--- a/packages/erd-editor/src/utils/generator-code/index.ts
+++ b/packages/erd-editor/src/utils/generator-code/index.ts
@@ -6,6 +6,7 @@ import {
   createCode as createCodeCsharp,
   formatTable as formatTableCsharp,
 } from './csharp';
+import { createCode as createCodeGo, formatTable as formatTableGo } from './go';
 import {
   createCode as createCodeGraphql,
   formatTable as formatTableGraphql,
@@ -51,6 +52,8 @@ export function createGeneratorCode(state: RootState): string {
       return createCodeKotlin(state);
     case Language.Scala:
       return createCodeScala(state);
+    case Language.Go:
+      return createCodeGo(state);
   }
 
   return '';
@@ -92,6 +95,10 @@ export function createGeneratorCodeTable(
       break;
     case Language.Scala:
       formatTableScala(state, { buffer, table });
+      buffer.push('');
+      break;
+    case Language.Go:
+      formatTableGo(state, { buffer, table });
       buffer.push('');
       break;
   }

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -34,7 +34,7 @@ only; they do not appear in the Command Palette.
   reads `CREATE TABLE`, `CREATE INDEX` and `ALTER TABLE` constraints and skips what it does
   not recognize, so an awkward dump imports partially rather than failing outright
 - **SQL DDL export** — Databricks, MariaDB, MSSQL, MySQL, Oracle, PostgreSQL, SQLite
-- **Code generation** — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala
+- **Code generation** — TypeScript, GraphQL, C#, Java, JPA, Kotlin, Scala, Go
 - **Visualization** — a force-directed view of how the tables actually relate
 - **Export** — `.erd.json`, `.sql`, `.png`
 - **Quick search** — `Ctrl`/`Cmd`+`K` to jump to any table, or run any editor command


### PR DESCRIPTION
Adds Go to the Generator Code panel, closing the request in discussion #268 — which until now was answered by `@vuerd/plugin-generate-template`, a plugin with no v3 equivalent.

## Output

```go
// application user
type UserAccount struct {
	// user id
	Id    int64  `json:"id"`
	Email string `json:"email"`
	// display name
	NickName   *string          `json:"nick_name"`
	Balance    *decimal.Decimal `json:"balance"`
	IsActive   bool             `json:"is_active"`
	LoginCount int32            `json:"login_count"`
	CreatedAt  time.Time        `json:"created_at"`
	// soft delete
	DeletedAt *time.Time `json:"deleted_at"`
}
```

The shape follows what a Go model looks like in the ecosystem rather than what the other seven generators emit: `json` tags, a pointer for a column that is not NOT NULL, `time.Time` for the three date primitives, sized numerics, and `decimal.Decimal` for DECIMAL — the one type Go has no standard answer for. As in the Java and Kotlin generators, no `package` clause and no import block are emitted; the two names that need one are `time` and shopspring's `decimal`.

| primitive | Go |
| --- | --- |
| `int` / `long` | `int32` / `int64` |
| `float` / `double` | `float32` / `float64` |
| `decimal` | `decimal.Decimal` |
| `boolean` | `bool` |
| `string` / `lob` | `string` |
| `date` / `dateTime` / `time` | `time.Time` |

## Two things Go forces that no sibling generator has to think about

**Exported identifiers.** An unexported name is invisible to `encoding/json` and to any package importing the struct, so the struct name and every field name are forced to an uppercase first letter. The name case setting therefore only picks the spelling, and the tag carries the column as the database spells it — otherwise a `snake_case` column under a camelCase setting would lose the name the driver needs. `upperFirst` rather than `toLocaleUpperCase`, so a Turkish locale does not turn `id` into `İd` and the same diagram generates the same text everywhere.

**Tags are string literals.** A backtick in a column name would terminate the raw string and the file would not compile, so such a column falls back to the interpreted form. `reflect.StructTag` unquotes the value, so a quote or a backslash is escaped in both forms and reads back as the column name.

## gofmt fidelity

The alignment block restarts at every comment line, because gofmt runs struct fields through a tabwriter whose column block ends at the first line that is not a field. `database/sql` shows it: `DB.numOpen` sits at column 13 and `DB.openerCh`, one comment further down, at 18.

Verified end to end against go1.23.4, not just asserted:

- `gofmt -d` over the generated text is **empty** — byte-identical to gofmt's own output
- `go vet` passes, including its `structtag` analyser
- `go build` compiles, and a reflection test confirms the tags read back to the original column names for `` we`ird ``, `say"hi` and `back\slash`

## Schema

`Language` gains an eighth flag at 128, appended after Scala. A stored document holds the number rather than the name, so the value cannot be slotted in alphabetically — that would remap every diagram already saved.

The v2 schema is deliberately left alone. A real older vuerd re-runs its own `validString(LanguageList)` and downgrades an unknown language back to GraphQL anyway, so widening v2 would buy nothing outside this repo. That makes a Go document lossy through a v2 round trip, the same way `csharp` and the Databricks database already are, and the convert specs now pin it.

`json-schema/schema.json` is hand-written and its `$schema` URL points at main — until this widening lands there, every Go document reads as schema-invalid in an editor that follows it.

## Verification

`pnpm check` clean, `pnpm test` green across all nine suites, `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
