### PR TITLE
build(erd-editor-shiki-worker): Migrate to Shiki 4 on the JavaScript regex engine

### DIFF
--- a/packages/erd-editor-shiki-worker/AGENTS.md
+++ b/packages/erd-editor-shiki-worker/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../../AGENTS.md -->
-<!-- Generated: 2026-08-17 | Updated: 2026-08-17 -->
+<!-- Generated: 2026-08-17 | Updated: 2026-08-24 -->
 
 # erd-editor-shiki-worker
 
@@ -7,10 +7,9 @@
 
 Runs [Shiki](https://shiki.style) syntax highlighting off the main thread. `getShikiService()` spawns
 a `SharedWorker` and returns a Comlink proxy of `ShikiService`, whose only method is
-`codeToHtml(code, { lang, theme })` over nine grammars (sql, typescript, graphql, csharp, java,
-kotlin, scala, go, python) and the github-dark / github-light themes. Published to npm at v0.1.2; `app`,
-`vscode-webview` and `intellij-webview` `import()` it lazily and pass the factory to
-`@dineug/erd-editor`'s `setGetShikiServiceCallback`.
+`codeToHtml(code, { lang, theme })` over nine grammars (sql, typescript, graphql, csharp, java, kotlin,
+scala, go, python) and the github-dark / github-light themes. Published to npm at v0.1.2; `app`,
+`vscode-webview` and `intellij-webview` `import()` it lazily into `setGetShikiServiceCallback`.
 
 ## Key Files
 
@@ -18,9 +17,9 @@ kotlin, scala, go, python) and the github-dark / github-light themes. Published 
 | --- | --- |
 | `src/index.ts` | Public surface: `getShikiService` plus the `ShikiService` type |
 | `src/services/index.ts` | Constructs the shared worker, `Comlink.wrap`s its port, memoizes the proxy |
-| `src/services/shikiService.ts` | The service itself — WASM load, grammar/theme tables, `codeToHtml` |
+| `src/services/shikiService.ts` | The service itself — `createHighlighterCore`, grammar/theme tables, `codeToHtml` |
 | `src/services/shiki.shared-worker.ts` | `SharedWorker` entry; `Comlink.expose`s the service per connection |
-| `vite.config.ts` | `run.tasks.build`, ES lib build, `__APP_VERSION__` define, `dts()` |
+| `vite.config.ts` | `run.tasks.build`, ES lib build, `__APP_VERSION__` define, `dts()`, `base64InlineWorker()` |
 | `tsconfig.json` | Adds `WebWorker` to `lib` — without it the worker entries do not typecheck |
 
 ## Subdirectories
@@ -33,26 +32,29 @@ kotlin, scala, go, python) and the github-dark / github-light themes. Published 
 
 ### Working In This Directory
 
-- **Only the shared worker is wired up.** `getShikiService` builds `ShikiSharedWorker`; the
-  dedicated-worker fallback (`src/services/shiki.worker.ts`) is commented out in the `catch`, so a
-  host without `SharedWorker` logs the error and returns no proxy. Keep both entries on the same API.
+- **Only the shared worker is wired up.** The `shiki.worker.ts` fallback is commented out in
+  `getShikiService`'s `catch` — no `SharedWorker` means a logged error and no proxy. Keep both on one API.
 - **Everything crossing the Comlink boundary must be structured-cloneable or a Comlink proxy.**
   Returning a class instance or DOM node from `shikiService.ts` fails at runtime, not at build.
-- **`shiki` is pinned to exactly `0.14.7`.** `shikiService.ts` binds to `setWasm` / `toShikiTheme` and to
-  `shiki/languages/*.tmLanguage.json`, `shiki/themes/*.json`, `shiki/dist/onig.wasm` — a bump rewrites it.
-- Grammars and themes drive bundle size (built bundle ~1.4 MB); add one only when the editor uses it.
+- **`createHighlighterCore` over static `@shikijs/langs/*` / `@shikijs/themes/*` imports** — `shiki`'s default entry pulls every grammar, and inlined as one `data:` URI the worker cannot code-split.
+- **The engine is `createJavaScriptRegexEngine({ forgiving: true })`, not Oniguruma** — no WASM, so no
+  `wasm-unsafe-eval` in a host CSP. `forgiving` hides an untranspilable grammar as missing colour, so check Shiki's engine-js compat list when adding one.
+- Grammars and themes drive both the bundle (~1.4 MB, ~176 kB gzipped) and the inlined worker URL (~1.62 MB of a 2 MiB cap) — and those two move independently.
 
 ### Testing Requirements
 
 - No `test` task, and `scripts` is empty, so the build is the only gate:
   `pnpm exec vp run --filter @dineug/erd-editor-shiki-worker --fail-if-no-match build`.
-- Behavioural check: `pnpm --filter @dineug/erd-editor dev` (its `src/index.dev.ts` imports `getShikiService`), then open the Schema SQL and Generator Code panels.
+- **The build never spawns the worker, so green proves nothing about the highlighter starting.** Verify
+  in a browser: `pnpm --filter @dineug/erd-editor dev`, then the Schema SQL and Generator Code panels.
 
 ### Common Patterns
 
-- Worker entries import through Vite suffixes: `'./shiki.shared-worker?sharedworker&inline'`.
-  `&inline` embeds the worker as a `data:` URI so consumers re-bundling this package never fetch a
-  second asset under a webview CSP; `shiki/dist/onig.wasm?url` inlines as base64 the same way.
+- Worker entries import through Vite suffixes: `'./shiki.shared-worker?sharedworker&inline'`. `&inline`
+  embeds it as a `data:` URI, so consumers re-bundling this package fetch no second asset under a CSP.
+- **`base64InlineWorker()` in `vite.config.ts` re-encodes that URI from percent to base64.** Percent
+  inflates grammars 1.8x and blew past Chromium's 2 MiB URL cap, where `new SharedWorker` fails with an
+  empty error event — no log, no stack, just panels that never fill. It fails the build over the cap.
 - The worker is named `@dineug/erd-editor-shiki-worker?v${__APP_VERSION__}` — `SharedWorker` is keyed
   by name, so the version stamp keeps two editor versions off one stale highlighter.
 
@@ -64,7 +66,7 @@ None — leaf package.
 
 ### External
 
-- `shiki` `0.14.7` — highlighting engine, exact pin
+- `shiki` / `@shikijs/langs` / `@shikijs/themes` `4.4.3` — engine plus fine-grained grammar and theme entries; exact pins that move as a set
 - `comlink` `4.4.1` — worker RPC, exact pin; inlined into the bundle, so consumers need not depend on it
 
 <!-- MANUAL: notes added below this line are preserved on regeneration -->

--- a/packages/erd-editor-shiki-worker/README.md
+++ b/packages/erd-editor-shiki-worker/README.md
@@ -7,8 +7,8 @@ This package supplies the highlighter they look for. It is not a standalone high
 plugs into the editor through that package's `setGetShikiServiceCallback` export.
 
 It ships separately because highlighting is optional and expensive: [Shiki](https://shiki.style),
-its WASM regex engine and nine TextMate grammars build out to well over a megabyte, with the
-worker and the WASM both inlined as `data:` URIs. Keeping it out of the editor means you pay
+its JavaScript regex engine and nine TextMate grammars build out to well over a megabyte, with
+the worker inlined as a `data:` URI. Keeping it out of the editor means you pay
 that only where you actually load this package — and when you do, tokenizing runs in a shared
 worker that is named per version, so every editor on the page, and in other tabs on the same
 origin, talks to one highlighter instead of one each.
@@ -62,8 +62,9 @@ code generators (the JPA generator emits Java, the SQLAlchemy generator emits Py
 
 - The worker is bundled inline, so there is no extra file to copy or host. Importing the
   package is the whole deployment step.
-- A host page with a strict CSP needs `worker-src data:` and `script-src 'wasm-unsafe-eval'`.
-  Without them the worker fails to construct, the error is logged, and the panels stay plain.
+- A host page with a strict CSP needs `worker-src data:`. Without it the worker fails to
+  construct, the error is logged, and the panels stay plain. No WASM directive is required —
+  the regex engine is plain JavaScript.
 - Where `SharedWorker` is missing — Chrome on Android, Safari before 16.4 — no service is
   returned and the underlying error is logged to the console. The editor treats that as "no
   highlighter" and renders the code panels as plain text; nothing else is affected.

--- a/packages/erd-editor-shiki-worker/package.json
+++ b/packages/erd-editor-shiki-worker/package.json
@@ -28,7 +28,9 @@
   "scripts": {},
   "devDependencies": {
     "comlink": "4.4.1",
-    "shiki": "0.14.7",
+    "@shikijs/langs": "4.4.3",
+    "@shikijs/themes": "4.4.3",
+    "shiki": "4.4.3",
     "tslib": "^2.8.1",
     "typescript": "7.0.2",
     "vite": "catalog:",

--- a/packages/erd-editor-shiki-worker/src/services/shikiService.ts
+++ b/packages/erd-editor-shiki-worker/src/services/shikiService.ts
@@ -1,101 +1,44 @@
-import { getHighlighter, setWasm, toShikiTheme } from 'shiki';
-// @ts-ignore
-import wasmUrl from 'shiki/dist/onig.wasm?url';
-import csharp from 'shiki/languages/csharp.tmLanguage.json';
-import go from 'shiki/languages/go.tmLanguage.json';
-import graphql from 'shiki/languages/graphql.tmLanguage.json';
-import java from 'shiki/languages/java.tmLanguage.json';
-import kotlin from 'shiki/languages/kotlin.tmLanguage.json';
-import python from 'shiki/languages/python.tmLanguage.json';
-import scala from 'shiki/languages/scala.tmLanguage.json';
-import sql from 'shiki/languages/sql.tmLanguage.json';
-import typescript from 'shiki/languages/typescript.tmLanguage.json';
-import githubDark from 'shiki/themes/github-dark.json';
-import githubLight from 'shiki/themes/github-light.json';
+import csharp from '@shikijs/langs/csharp';
+import go from '@shikijs/langs/go';
+import graphql from '@shikijs/langs/graphql';
+import java from '@shikijs/langs/java';
+import kotlin from '@shikijs/langs/kotlin';
+import python from '@shikijs/langs/python';
+import scala from '@shikijs/langs/scala';
+import sql from '@shikijs/langs/sql';
+import typescript from '@shikijs/langs/typescript';
+import githubDark from '@shikijs/themes/github-dark';
+import githubLight from '@shikijs/themes/github-light';
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
-const themeMap: Record<string, any> = {
-  dark: githubDark,
-  light: githubLight,
-};
-
-const languages: Array<any> = [
-  {
-    id: 'typescript',
-    scopeName: 'source.ts',
-    displayName: 'TypeScript',
-    aliases: ['ts'],
-    grammar: typescript,
-  },
-  {
-    id: 'sql',
-    scopeName: 'source.sql',
-    displayName: 'SQL',
-    grammar: sql,
-  },
-  {
-    id: 'graphql',
-    scopeName: 'source.graphql',
-    displayName: 'GraphQL',
-    aliases: ['gql'],
-    grammar: graphql,
-  },
-  {
-    id: 'csharp',
-    scopeName: 'source.cs',
-    displayName: 'C#',
-    aliases: ['c#', 'cs'],
-    grammar: csharp,
-  },
-  {
-    id: 'java',
-    scopeName: 'source.java',
-    displayName: 'Java',
-    grammar: java,
-  },
-  {
-    id: 'kotlin',
-    scopeName: 'source.kotlin',
-    displayName: 'Kotlin',
-    aliases: ['kt', 'kts'],
-    grammar: kotlin,
-  },
-  {
-    id: 'scala',
-    scopeName: 'source.scala',
-    displayName: 'Scala',
-    grammar: scala,
-  },
-  {
-    id: 'go',
-    scopeName: 'source.go',
-    displayName: 'Go',
-    aliases: ['golang'],
-    grammar: go,
-  },
-  {
-    id: 'python',
-    scopeName: 'source.python',
-    displayName: 'Python',
-    aliases: ['py'],
-    grammar: python,
-  },
-];
+const themeMap = {
+  dark: 'github-dark',
+  light: 'github-light',
+} as const;
 
 function getThemeKey(theme?: string): 'dark' | 'light' {
   return theme === 'dark' || theme === 'light' ? theme : 'dark';
 }
 
 export class ShikiService {
-  private ready: Promise<void>;
+  private highlighter: Promise<HighlighterCore>;
 
   constructor() {
-    this.ready = new Promise((resolve, reject) => {
-      fetch(wasmUrl)
-        .then(wasmResponse => {
-          setWasm(wasmResponse);
-          resolve();
-        })
-        .catch(reject);
+    this.highlighter = createHighlighterCore({
+      themes: [githubDark, githubLight],
+      langs: [
+        sql,
+        typescript,
+        graphql,
+        csharp,
+        java,
+        kotlin,
+        scala,
+        go,
+        python,
+      ],
+      engine: createJavaScriptRegexEngine({ forgiving: true }),
     });
   }
 
@@ -118,13 +61,11 @@ export class ShikiService {
       theme?: 'dark' | 'light';
     }
   ): Promise<string> {
-    return await this.ready.then(async () => {
-      const highlighter = await getHighlighter({
-        theme: toShikiTheme(Reflect.get(themeMap, getThemeKey(theme))),
-        langs: languages,
-      });
+    const highlighter = await this.highlighter;
 
-      return highlighter.codeToHtml(code, { lang });
+    return highlighter.codeToHtml(code, {
+      lang,
+      theme: themeMap[getThemeKey(theme)],
     });
   }
 }

--- a/packages/erd-editor-shiki-worker/vite.config.ts
+++ b/packages/erd-editor-shiki-worker/vite.config.ts
@@ -14,6 +14,89 @@ const banner = `/*!
  * @license ${pkg.license}
  */`;
 
+/** Chromium이 URL 하나에 허용하는 최대 길이. 넘기면 워커가 로드되지 않는다. */
+const MAX_URL_LENGTH = 2 * 1024 * 1024;
+
+const INLINE_WORKER_URL =
+  /"data:text\/javascript;charset=utf-8," \+ encodeURIComponent\((\w+)\)/g;
+
+/**
+ * `?sharedworker&inline`이 만드는 워커 URL을 percent 인코딩에서 base64로 바꾼다.
+ *
+ * percent 인코딩은 TextMate 문법의 `"` `{` `\` 를 전부 `%XX` 3자로 부풀려 1.8배가
+ * 되는데, 그 결과가 `MAX_URL_LENGTH`를 넘으면 `new SharedWorker`가 **본문이 빈**
+ * 에러 이벤트만 남기고 실패한다. Comlink는 응답을 영원히 기다리고 패널은 조용히
+ * 빈 채로 남는다 — 로그도 스택도 없다. base64는 1.33배고, blob URL과 달리 같은
+ * 소스가 항상 같은 URL이라 탭마다 SharedWorker가 갈라지지 않는다.
+ */
+function base64InlineWorker() {
+  return {
+    name: 'erd-editor:base64-inline-worker',
+    renderChunk(code: string) {
+      const matches = [...code.matchAll(INLINE_WORKER_URL)];
+      if (!matches.length) return null;
+
+      for (const [, ident] of matches) {
+        const source = readStringLiteral(code, ident);
+        // 워커 소스를 못 읽으면 길이를 잴 수 없다. 조용한 실패로 돌아가느니 멈춘다.
+        if (source === null) {
+          throw new Error(
+            `[base64InlineWorker] could not read the inlined worker source \`${ident}\``
+          );
+        }
+
+        const length =
+          'data:text/javascript;base64,'.length +
+          4 * Math.ceil(Buffer.byteLength(source, 'utf8') / 3);
+        if (length > MAX_URL_LENGTH) {
+          throw new Error(
+            `[base64InlineWorker] inlined worker URL is ${length} chars, over the ${MAX_URL_LENGTH} limit ` +
+              `by ${length - MAX_URL_LENGTH}. Drop a grammar or theme — shipping this builds a highlighter that never starts.`
+          );
+        }
+      }
+
+      // 배너가 파일 첫머리를 지키도록 뒤에 붙인다. 함수 선언이라 호이스팅된다.
+      return {
+        code: `${code.replace(
+          INLINE_WORKER_URL,
+          (_, ident) => `__toDataUrl(${ident})`
+        )}\n${TO_DATA_URL}`,
+        map: null,
+      };
+    },
+  };
+}
+
+const TO_DATA_URL = `function __toDataUrl(source) {
+\tconst bytes = new TextEncoder().encode(source);
+\tlet binary = "";
+\tfor (let i = 0; i < bytes.length; i += 0x8000) {
+\t\tbinary += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+\t}
+\treturn "data:text/javascript;base64," + btoa(binary);
+}`;
+
+/** `var <ident> = "..."`의 문자열 리터럴을 이스케이프를 지켜가며 읽어 값으로 돌려준다. */
+function readStringLiteral(code: string, ident: string): string | null {
+  const declaration = new RegExp(
+    `(?:var|const|let)\\s+${ident}\\s*=\\s*"`
+  ).exec(code);
+  if (!declaration) return null;
+
+  const start = declaration.index + declaration[0].length;
+  for (let i = start; i < code.length; i++) {
+    if (code[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (code[i] === '"') {
+      return Function(`return "${code.slice(start, i)}"`)();
+    }
+  }
+  return null;
+}
+
 export default defineConfig({
   /**
    * nx.json `targetDefaults`의 대체. `dependsOn`이 `^build`를, `output`이
@@ -73,5 +156,5 @@ export default defineConfig({
       '@': join(import.meta.dirname, 'src'),
     },
   },
-  plugins: lazyPlugins(() => [dts()]),
+  plugins: lazyPlugins(() => [dts(), base64InlineWorker()]),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,12 @@ importers:
 
   packages/erd-editor-shiki-worker:
     devDependencies:
+      '@shikijs/langs':
+        specifier: 4.4.3
+        version: 4.4.3
+      '@shikijs/themes':
+        specifier: 4.4.3
+        version: 4.4.3
       '@typescript/typescript6':
         specifier: 6.0.2
         version: 6.0.2
@@ -367,8 +373,8 @@ importers:
         specifier: 4.4.1
         version: 4.4.1
       shiki:
-        specifier: 0.14.7
-        version: 0.14.7
+        specifier: 4.4.3
+        version: 4.4.3
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -3827,6 +3833,37 @@ packages:
     resolution: {integrity: sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==}
     engines: {node: '>=18'}
 
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
     engines: {node: '>=18'}
@@ -4075,6 +4112,9 @@ packages:
   '@types/geojson@7946.0.13':
     resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
@@ -4086,6 +4126,9 @@ packages:
 
   '@types/luxon@3.4.2':
     resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/mdx@2.0.7':
     resolution: {integrity: sha512-BG4tyr+4amr3WsSEmHn/fXPqaCba/AYZ7dsaQTiavihQunHSIxk+uAtqsjvicNpyHN6cm+B9RVrUOtW9VzIKHw==}
@@ -4121,6 +4164,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/vscode-webview@1.57.5':
     resolution: {integrity: sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==}
@@ -4257,6 +4303,9 @@ packages:
   '@typescript/typescript6@6.0.2':
     resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vitejs/plugin-legacy@8.2.3':
     resolution: {integrity: sha512-MMHLsn/0FrBkCQyb1x44cPYGwkfqcGr2FblcEP2ne79aXe7d5tFKoZ09xs5C4wuh8fOu2JRaNhgAS3K3uvUeJA==}
@@ -4710,9 +4759,6 @@ packages:
     resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
-  ansi-sequence-parser@1.1.1:
-    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
-
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -4925,6 +4971,9 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -4944,6 +4993,12 @@ packages:
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -5005,6 +5060,9 @@ packages:
 
   comlink@4.4.2:
     resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -5328,6 +5386,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   dexie@3.2.7:
     resolution: {integrity: sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==}
     engines: {node: '>=6.0'}
@@ -5477,6 +5538,7 @@ packages:
   eslint@9.22.0:
     resolution: {integrity: sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5798,6 +5860,12 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -5816,6 +5884,9 @@ packages:
 
   html-to-image@1.11.11:
     resolution: {integrity: sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -6171,9 +6242,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
@@ -6365,12 +6433,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -6485,6 +6571,12 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -6661,6 +6753,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -6789,6 +6884,15 @@ packages:
 
   regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -6945,8 +7049,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@0.14.7:
-    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7009,6 +7114,9 @@ packages:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -7098,6 +7206,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -7233,6 +7344,9 @@ packages:
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -7310,6 +7424,21 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -7400,6 +7529,12 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vite-plugin-dts@5.0.3:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
     peerDependencies:
@@ -7479,12 +7614,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vscode-oniguruma@1.7.0:
-    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-
-  vscode-textmate@8.0.0:
-    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -7690,6 +7819,9 @@ packages:
 
   yuku-parser@0.5.48:
     resolution: {integrity: sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -10880,6 +11012,46 @@ snapshots:
       '@sentry/browser-utils': 10.70.0
       '@sentry/core': 10.70.0
 
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -11176,6 +11348,10 @@ snapshots:
 
   '@types/geojson@7946.0.13': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/highlight-words-core@1.2.3': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -11183,6 +11359,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/luxon@3.4.2': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/mdx@2.0.7': {}
 
@@ -11215,6 +11395,8 @@ snapshots:
   '@types/stylis@4.2.7': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/vscode-webview@1.57.5': {}
 
@@ -11289,6 +11471,8 @@ snapshots:
   '@typescript/typescript6@6.0.2':
     dependencies:
       '@typescript/old': typescript@6.0.3
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-legacy@8.2.3(@voidzero-dev/vite-plus-core@0.2.9(@types/node@22.20.1)(jiti@2.6.1)(terser@5.26.0)(typescript@7.0.2)(yaml@2.7.0))(terser@5.26.0)':
     dependencies:
@@ -11794,8 +11978,6 @@ snapshots:
 
   ansi-regex@6.3.0: {}
 
-  ansi-sequence-parser@1.1.1: {}
-
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -12040,6 +12222,8 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
+  ccount@2.0.1: {}
+
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -12062,6 +12246,10 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.4.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   check-error@2.1.1: {}
 
@@ -12121,6 +12309,8 @@ snapshots:
   comlink@4.4.1: {}
 
   comlink@4.4.2: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -12466,6 +12656,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dexie@3.2.7: {}
 
@@ -13023,6 +13217,24 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   he@1.2.0: {}
 
   help-me@5.0.0: {}
@@ -13036,6 +13248,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-to-image@1.11.11: {}
+
+  html-void-elements@3.0.0: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -13336,8 +13550,6 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-parser@3.2.0: {}
-
   jsonc-parser@3.3.1: {}
 
   jsonfile@6.1.0:
@@ -13502,10 +13714,39 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   meow@13.2.0: {}
 
   merge-stream@2.0.0:
     optional: true
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   mime-db@1.52.0:
     optional: true
@@ -13653,6 +13894,14 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   open@10.2.0:
     dependencies:
@@ -13994,6 +14243,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  property-information@7.2.0: {}
+
   punycode@2.3.0: {}
 
   quansync@0.2.8: {}
@@ -14179,6 +14430,16 @@ snapshots:
   regenerator-transform@0.15.2:
     dependencies:
       '@babel/runtime': 7.29.7
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -14389,12 +14650,16 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@0.14.7:
+  shiki@4.4.3:
     dependencies:
-      ansi-sequence-parser: 1.1.1
-      jsonc-parser: 3.2.0
-      vscode-oniguruma: 1.7.0
-      vscode-textmate: 8.0.0
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
 
   side-channel-list@1.0.0:
     dependencies:
@@ -14461,6 +14726,8 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
 
@@ -14592,6 +14859,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@3.3.0:
     dependencies:
       get-own-enumerable-property-symbols: 3.0.2
@@ -14701,6 +14973,8 @@ snapshots:
     dependencies:
       punycode: 2.3.0
 
+  trim-lines@3.0.1: {}
+
   ts-dedent@2.2.0: {}
 
   tslib@2.8.1: {}
@@ -14799,6 +15073,29 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.0: {}
 
   unplugin-dts@1.0.3(@microsoft/api-extractor@7.51.1(@types/node@22.20.1))(@voidzero-dev/vite-plus-core@0.2.9(@types/node@22.20.1)(jiti@2.6.1)(terser@5.26.0)(typescript@7.0.2)(yaml@2.7.0))(rolldown@1.2.4)(rollup@4.62.4)(typescript@7.0.2)(webpack@5.91.0):
@@ -14872,6 +15169,16 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.51.1(@types/node@22.20.1))(@voidzero-dev/vite-plus-core@0.2.9(@types/node@22.20.1)(jiti@2.6.1)(terser@5.26.0)(typescript@7.0.2)(yaml@2.7.0))(rolldown@1.2.4)(rollup@4.62.4)(typescript@7.0.2)(webpack@5.91.0):
     dependencies:
@@ -15133,10 +15440,6 @@ snapshots:
       happy-dom: 20.11.2
     transitivePeerDependencies:
       - msw
-
-  vscode-oniguruma@1.7.0: {}
-
-  vscode-textmate@8.0.0: {}
 
   vscode-uri@3.1.0: {}
 
@@ -15493,3 +15796,5 @@ snapshots:
       '@yuku-parser/binding-linux-x64-musl': 0.5.48
       '@yuku-parser/binding-win32-arm64': 0.5.48
       '@yuku-parser/binding-win32-x64': 0.5.48
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
Migrates `@dineug/erd-editor-shiki-worker` from Shiki `0.14.7` to `4.4.3`, on the JavaScript regex engine.

## What changed

**The service.** `0.14.7` bound us to `setWasm` / `toShikiTheme` and to `shiki/languages/*.tmLanguage.json`, none of which survive into 4.x. `shikiService.ts` is now `createHighlighterCore` over fine-grained `@shikijs/langs/*` and `@shikijs/themes/*` entries, which let the hand-written 9-entry grammar table go — the registrations carry their own `scopeName` and aliases. One highlighter now holds both themes rather than being rebuilt per call.

**The engine.** `createJavaScriptRegexEngine({ forgiving: true })` replaces Oniguruma. No WASM to fetch or inline, and a host CSP no longer needs `script-src 'wasm-unsafe-eval'` — only `worker-src data:`. All nine grammars are on Shiki's [engine-js compat list](https://shiki.style/references/engine-js-compat); `forgiving` keeps a future one that isn't from rejecting `codeToHtml` into a blank panel.

**The inlined worker URL.** The migration on its own shipped a highlighter that never starts, so this PR also adds `base64InlineWorker()` to `vite.config.ts`. Details below.

## The URL cap

Vite inlines the shared worker as `new SharedWorker("data:…," + encodeURIComponent(src))`. Percent-encoding inflates TextMate grammar JSON ~1.8x, where the base64 WASM it replaced cost ~1.0x — so the worker got *smaller* in bytes while its URL got *bigger*, past Chromium's 2 MiB cap:

| | 0.14.7 | 4.4.3 (before fix) | 4.4.3 (after fix) |
| --- | --- | --- | --- |
| Worker source | 1,292,521 chars | 1,214,232 chars | 1,214,232 chars |
| Encoding inflation | 1.429x (percent) | 1.80x (percent) | 1.333x (base64) |
| Worker URL | 1,846,572 | **2,181,309** | 1,619,476 |
| vs. 2 MiB cap | 250,580 free | **84,157 over** | 477,676 free |
| Browser | works | **fails** | works |

Over the cap, `new SharedWorker` fails with an error event whose fields are blank by design. Comlink then waits on a reply that never comes, so `CodeBlock.tsx`'s `.then()` never runs and the panels stay plain — with nothing in the console.

`base64InlineWorker()` re-encodes that URL as base64 and **fails the build** if it would ever exceed the cap:

```
Error: [base64InlineWorker] inlined worker URL is 2181309 chars, over the 2097152 limit
by 84157. Drop a grammar or theme — shipping this builds a highlighter that never starts.
```

base64 rather than a `blob:` URL: both clear the size problem, but `URL.createObjectURL` mints a fresh URL per tab, and `SharedWorker` is keyed by (origin, URL, name) — that would split the highlighter per tab and lose the cross-tab sharing this package exists for. Encoding runs at call time rather than build time so the base64 doesn't land in the shipped bundle and cost gzip.

## Verification

- **Browser (Chromium, real `getShikiService()` → `SharedWorker`):** all 9 grammars × both themes highlight; `pre.shiki` and its inline `background-color` — which `CodeBlock.tsx` reads — survive v4's markup change.
- **Build guard:** confirmed it fails the build when the URL exceeds the cap.
- **Consumer bundles:** `app`, `vscode-extension` and `intellij-webview` all carry the base64 construction, no `encodeURIComponent` left.
- `pnpm check`, `pnpm build`, `pnpm test` (9 suites) pass.

Gzip drops 340 kB → 176 kB. That number is also what hid the bug: it moves opposite to URL length here, and `pnpm build` never spawns the worker — noted in `AGENTS.md` so the next change verifies in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
