### PR TITLE
feat: Make CodeBlock selectable through a transparent textarea overlay

### DIFF
--- a/packages/erd-editor/src/components/erd/useErdShortcut.test.ts
+++ b/packages/erd-editor/src/components/erd/useErdShortcut.test.ts
@@ -931,6 +931,34 @@ describe('useErdShortcut - clipboard', () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  // the copy twin above has read the target since AC-32; paste did not, so text
+  // pasted into a memo or the Schema SQL overlay also landed on the diagram.
+  it.each([
+    ['textarea', () => document.createElement('textarea')],
+    ['input', () => document.createElement('input')],
+    [
+      'contenteditable',
+      () => {
+        const el = document.createElement('div');
+        el.setAttribute('contenteditable', '');
+        return el;
+      },
+    ],
+  ])('ignores paste while the target is inside a %s', async (_, create) => {
+    const app = await setup();
+    const tableId = seedTable(app);
+    const { event, preventDefault } = createClipboardEvent(
+      { 'text/plain': 'nickname' },
+      create()
+    );
+
+    app.emitter.emit(pasteAction({ event }));
+    await flush();
+
+    expect(getTable(app, tableId)?.columnIds ?? []).toHaveLength(0);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
   it('ignores paste while the focused table is being edited', async () => {
     const app = await setup();
     const tableId = seedTable(app);

--- a/packages/erd-editor/src/components/erd/useErdShortcut.ts
+++ b/packages/erd-editor/src/components/erd/useErdShortcut.ts
@@ -284,6 +284,7 @@ export function useErdShortcut(ctx: Ctx) {
     if (showHighLevelTable || editor.focusTable?.edit || !event.clipboardData) {
       return;
     }
+    if (isEditableTarget(event.target)) return;
 
     const result = readClipboardPayload(event.clipboardData);
 

--- a/packages/erd-editor/src/components/generator-code/GeneratorCode.test.ts
+++ b/packages/erd-editor/src/components/generator-code/GeneratorCode.test.ts
@@ -85,6 +85,12 @@ const rootOf = (m: Mounted) =>
 const codeOf = (m: Mounted) =>
   m.container.querySelector('.scrollbar') as HTMLDivElement;
 
+/**
+ * CodeBlock strips the generators' trailing blank line, which a textarea turns into a real last
+ * line and a block container does not.
+ */
+const rendered = (code: string) => code.replace(/\n+$/, '');
+
 const copyButtonOf = (m: Mounted) =>
   m.container.querySelector('[title="Copy"]') as HTMLDivElement;
 
@@ -141,7 +147,7 @@ describe('GeneratorCode', () => {
     expect(root).toBeTruthy();
     expect(root.contains(codeOf(mounted))).toBe(true);
     expect(codeOf(mounted).textContent).toBe(
-      createGeneratorCode(app.store.state)
+      rendered(createGeneratorCode(app.store.state))
     );
     expect(codeOf(mounted).textContent).toContain('type User {');
     expect(codeOf(mounted).textContent).toContain('userName: String');
@@ -159,7 +165,7 @@ describe('GeneratorCode', () => {
 
     const table = app.store.state.collections.tableEntities['table-a'];
     expect(codeOf(mounted).textContent).toBe(
-      createGeneratorCodeTable(app.store.state, table)
+      rendered(createGeneratorCodeTable(app.store.state, table))
     );
     expect(codeOf(mounted).textContent).toContain('type User {');
     expect(codeOf(mounted).textContent).not.toContain('type Post');
@@ -249,7 +255,7 @@ describe('GeneratorCode', () => {
       theme: 'light',
     });
     expect(codeToHtml.mock.calls.at(-1)?.[0]).toBe(
-      createGeneratorCode(app.store.state)
+      rendered(createGeneratorCode(app.store.state))
     );
   });
 

--- a/packages/erd-editor/src/components/primitives/code-block/CodeBlock.styles.test.ts
+++ b/packages/erd-editor/src/components/primitives/code-block/CodeBlock.styles.test.ts
@@ -1,21 +1,55 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
 
+import { adoptedRules, ruleOf } from '@/__test-utils__/adoptedCss';
 import * as styles from '@/components/primitives/code-block/CodeBlock.styles';
 
 const source = (tpl: { strings: TemplateStringsArray }) =>
   tpl.strings.raw.join('');
 
+/** Read from the emitted CSSOM: the shared block is an interpolation, which `source()` drops. */
+const ALIGNMENT = [
+  'padding',
+  'font-family',
+  'font-size',
+  'line-height',
+  'letter-spacing',
+  'font-weight',
+  'font-kerning',
+  'font-synthesis',
+  'font-variant-ligatures',
+  'font-variant-caps',
+  'font-style',
+  'text-transform',
+  'white-space',
+  'text-align',
+  'text-indent',
+  'tab-size',
+  '-webkit-text-size-adjust',
+];
+
+let rules: CSSStyleRule[] = [];
+
+beforeAll(() => {
+  rules = adoptedRules();
+});
+
 describe('CodeBlock.styles', () => {
-  it('exports the three css template literals the component renders with', () => {
+  it('exports the six css template literals the component renders with', () => {
     expect(styles.root).toBeTruthy();
-    expect(styles.code).toBeTruthy();
+    expect(styles.scroller).toBeTruthy();
+    expect(styles.layers).toBeTruthy();
+    expect(styles.preview).toBeTruthy();
+    expect(styles.textarea).toBeTruthy();
     expect(styles.clipboard).toBeTruthy();
   });
 
   it('resolves every export to a distinct non-empty class identifier', () => {
     const identifiers = [
       String(styles.root),
-      String(styles.code),
+      String(styles.scroller),
+      String(styles.layers),
+      String(styles.preview),
+      String(styles.textarea),
       String(styles.clipboard),
     ];
 
@@ -23,7 +57,7 @@ describe('CodeBlock.styles', () => {
       expect(typeof identifier).toBe('string');
       expect(identifier.length).toBeGreaterThan(0);
     });
-    expect(new Set(identifiers).size).toBe(3);
+    expect(new Set(identifiers).size).toBe(6);
   });
 
   it('positions the clipboard button and drives it from the foreground/active tokens', () => {
@@ -44,6 +78,14 @@ describe('CodeBlock.styles', () => {
     expect(styles.root.values).toContain(styles.clipboard);
   });
 
+  it('draws no focus ring, so the overlay never outlines the code it sits on', () => {
+    expect(
+      rules.filter(rule => rule.selectorText.includes(':focus'))
+    ).toHaveLength(0);
+    expect(source(styles.root)).not.toContain('outline: 1px');
+    expect(source(styles.textarea)).not.toContain('outline:');
+  });
+
   it('makes the root a relative, overflow-hidden box', () => {
     const root = source(styles.root);
 
@@ -52,13 +94,101 @@ describe('CodeBlock.styles', () => {
     expect(root).toContain('min-height: 40px');
   });
 
-  it('keeps the code area scrollable and on the code font token', () => {
-    const code = source(styles.code);
+  it('gives the component exactly one scroll container', () => {
+    const scrolling = rules.filter(
+      rule => rule.style.getPropertyValue('overflow') === 'auto'
+    );
 
-    expect(code).toContain('white-space: pre');
-    expect(code).toContain('overflow: auto');
-    expect(code).toContain('var(--code-font-family)');
-    expect(code).toContain('color: var(--active)');
-    expect(code).toContain('padding: 16px');
+    expect(scrolling).toHaveLength(1);
+    expect(scrolling[0].selectorText).toBe(`.${String(styles.scroller)}`);
+  });
+
+  it('leaves the scroll container in flow, so the root keeps a content height', () => {
+    const scroller = ruleOf(rules, `.${String(styles.scroller)}`);
+
+    // out of flow, the root — whose only other child is the absolute clipboard button — has
+    // nothing to size itself from wherever the parent chain is height-indefinite
+    expect(scroller.style.getPropertyValue('position')).toBe('');
+    expect(scroller.style.getPropertyValue('inset')).toBe('');
+    expect(scroller.style.getPropertyValue('width')).toBe('100%');
+    expect(scroller.style.getPropertyValue('height')).toBe('100%');
+  });
+
+  it('forbids the overlay a scroll offset of its own', () => {
+    const textarea = ruleOf(rules, `.${String(styles.textarea)}`);
+
+    expect(textarea.style.getPropertyValue('overflow')).toBe('hidden');
+    expect(textarea.style.getPropertyValue('position')).toBe('absolute');
+    expect(textarea.style.getPropertyValue('resize')).toBe('none');
+  });
+
+  it('sizes the layer box to its content so the overlay can be stretched onto it', () => {
+    const layers = ruleOf(rules, `.${String(styles.layers)}`);
+
+    expect(layers.style.getPropertyValue('position')).toBe('relative');
+    expect(layers.style.getPropertyValue('width')).toBe('max-content');
+    expect(layers.style.getPropertyValue('min-width')).toBe('100%');
+    expect(layers.style.getPropertyValue('min-height')).toBe('100%');
+  });
+
+  it('states every glyph-moving property identically on both layers', () => {
+    const preview = ruleOf(rules, `.${String(styles.preview)}`);
+    const textarea = ruleOf(rules, `.${String(styles.textarea)}`);
+
+    // `word-spacing` is the one declaration in the shared fragment happy-dom's parser drops, so it
+    // rests on the two templates splicing in the same fragment object rather than on the loop
+    expect(styles.preview.values[0]).toBeTruthy();
+    expect(styles.preview.values[0]).toBe(styles.textarea.values[0]);
+
+    for (const property of ALIGNMENT) {
+      const value = preview.style.getPropertyValue(property);
+      expect(value).not.toBe('');
+      expect(textarea.style.getPropertyValue(property)).toBe(value);
+    }
+    expect(preview.style.getPropertyValue('font-family')).toBe(
+      'var(--code-font-family)'
+    );
+    expect(preview.style.getPropertyValue('white-space')).toBe('pre');
+  });
+
+  it('hands the shiki markup the layer typography the UA takes away from pre and code', () => {
+    const inherited = ruleOf(rules, `.${String(styles.preview)} *`);
+
+    expect(inherited.style.getPropertyValue('font-family')).toBe('inherit');
+    expect(inherited.style.getPropertyValue('font-size')).toBe('inherit');
+    expect(inherited.style.getPropertyValue('line-height')).toBe('inherit');
+    expect(inherited.style.getPropertyValue('letter-spacing')).toBe('inherit');
+    expect(inherited.style.getPropertyValue('margin')).toBe('0px');
+    expect(inherited.style.getPropertyValue('padding')).toBe('0px');
+  });
+
+  it('paints the preview and hides the overlay text without hiding its caret', () => {
+    const preview = ruleOf(rules, `.${String(styles.preview)}`);
+    const textarea = ruleOf(rules, `.${String(styles.textarea)}`);
+
+    expect(preview.style.getPropertyValue('color')).toBe('var(--active)');
+    expect(preview.style.getPropertyValue('pointer-events')).toBe('none');
+    expect(preview.style.getPropertyValue('user-select')).toBe('none');
+    // WebKit drops the unprefixed property, and nothing in this pipeline autoprefixes
+    expect(preview.style.getPropertyValue('-webkit-user-select')).toBe('none');
+
+    expect(textarea.style.getPropertyValue('color')).toBe('transparent');
+    expect(textarea.style.getPropertyValue('background-color')).toBe(
+      'transparent'
+    );
+    expect(textarea.style.getPropertyValue('caret-color')).toBe(
+      'var(--active)'
+    );
+    expect(textarea.style.getPropertyValue('pointer-events')).toBe('');
+    expect(textarea.style.getPropertyValue('user-select')).toBe('');
+  });
+
+  it('paints the selection band from a translucent token over the highlighted code', () => {
+    const selection = ruleOf(rules, `.${String(styles.textarea)}::selection`);
+
+    expect(selection.style.getPropertyValue('color')).toBe('transparent');
+    expect(selection.style.getPropertyValue('background-color')).toBe(
+      'var(--placeholder)'
+    );
   });
 });

--- a/packages/erd-editor/src/components/primitives/code-block/CodeBlock.styles.ts
+++ b/packages/erd-editor/src/components/primitives/code-block/CodeBlock.styles.ts
@@ -1,5 +1,27 @@
 import { css } from '@dineug/r-html';
 
+/** Spliced into both layers: a textarea inherits none of `:host`'s typography, the preview does. */
+const layer = css`
+  padding: 16px;
+  font-family: var(--code-font-family);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-2);
+  letter-spacing: var(--letter-spacing-2);
+  font-weight: var(--font-weight-regular);
+  font-kerning: none;
+  font-synthesis: none;
+  font-variant-ligatures: none;
+  font-variant-caps: normal;
+  font-style: normal;
+  text-transform: none;
+  white-space: pre;
+  text-align: left;
+  text-indent: 0;
+  word-spacing: normal;
+  tab-size: 8;
+  -webkit-text-size-adjust: 100%;
+`;
+
 export const clipboard = css`
   position: absolute;
   top: 0;
@@ -11,6 +33,7 @@ export const clipboard = css`
   color: var(--foreground);
   opacity: 0;
   transition: opacity 0.15s;
+  -webkit-user-select: none;
   user-select: none;
 
   &:hover {
@@ -34,13 +57,55 @@ export const root = css`
   }
 `;
 
-export const code = css`
+/** Out of flow, the root loses its content height and collapses to `min-height`. */
+export const scroller = css`
   width: 100%;
   height: 100%;
-  white-space: pre;
   overflow: auto;
-  outline: none;
-  font-family: var(--code-font-family) !important;
+`;
+
+/** Sized by the preview, so the overlay stretched onto it has no scroll of its own to desync. */
+export const layers = css`
+  position: relative;
+  width: max-content;
+  min-width: 100%;
+  min-height: 100%;
+`;
+
+export const preview = css`
+  ${layer};
   color: var(--active);
-  padding: 16px;
+  pointer-events: none;
+  -webkit-user-select: none;
+  user-select: none;
+
+  /* the UA matches pre and code directly, which beats anything this rule only inherits down */
+  & * {
+    margin: 0;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+  }
+`;
+
+export const textarea = css`
+  ${layer};
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  resize: none;
+  appearance: none;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  background-color: transparent;
+  caret-color: var(--active);
+
+  /* painted above the code, so the band has to stay translucent — --placeholder is grayA-10 */
+  &::selection {
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    background-color: var(--placeholder);
+  }
 `;

--- a/packages/erd-editor/src/components/primitives/code-block/CodeBlock.test.ts
+++ b/packages/erd-editor/src/components/primitives/code-block/CodeBlock.test.ts
@@ -3,12 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { flush, mountAndFlush, Mounted } from '@/__test-utils__/index';
 import CodeBlock from '@/components/primitives/code-block/CodeBlock';
+import * as styles from '@/components/primitives/code-block/CodeBlock.styles';
 import {
   setGetShikiServiceCallback,
   ShikiService,
 } from '@/services/shikiService';
 
-const HIGHLIGHT = `<pre class="shiki" style="background-color:#123456"><code><span class="line">SELECT 1;</span></code></pre>`;
+const HIGHLIGHT = `<pre class="shiki" style="background-color:#123456" tabindex="0"><code><span class="line">SELECT 1;</span></code></pre>`;
 
 const createShikiService = (highlight = HIGHLIGHT) => {
   const codeToHtml = vi.fn<ShikiService['codeToHtml']>(async () => highlight);
@@ -16,11 +17,48 @@ const createShikiService = (highlight = HIGHLIGHT) => {
   return { service, codeToHtml };
 };
 
+/** A CodeBlock whose highlights stay in flight until the test resolves them by hand. */
+const pendingHighlight = () => {
+  const deferred: Array<(highlight: string) => void> = [];
+  const codeToHtml = vi.fn(
+    () => new Promise<string>(resolve => deferred.push(resolve))
+  );
+  setGetShikiServiceCallback(() => ({ codeToHtml }) as unknown as ShikiService);
+
+  const state = observable({
+    value: 'SELECT 1;',
+    theme: 'dark' as 'dark' | 'light',
+  });
+  const Pending: FC<any> = () => () =>
+    html`<${CodeBlock}
+      value=${state.value}
+      lang=${'sql'}
+      theme=${state.theme}
+    />`;
+
+  return { state, deferred, Pending };
+};
+
 const getRoot = (mounted: Mounted) =>
   mounted.container.firstElementChild as HTMLDivElement;
 
-const getCode = (mounted: Mounted) =>
-  mounted.container.querySelector('.scrollbar') as HTMLDivElement;
+const getScroller = (mounted: Mounted) =>
+  mounted.container.querySelector(
+    `.${String(styles.scroller)}`
+  ) as HTMLDivElement;
+
+const getLayers = (mounted: Mounted) =>
+  mounted.container.querySelector(
+    `.${String(styles.layers)}`
+  ) as HTMLDivElement;
+
+const getPreview = (mounted: Mounted) =>
+  mounted.container.querySelector(
+    `.${String(styles.preview)}`
+  ) as HTMLDivElement;
+
+const getTextarea = (mounted: Mounted) =>
+  mounted.container.querySelector('textarea') as HTMLTextAreaElement;
 
 const getClipboard = (mounted: Mounted) =>
   mounted.container.querySelector('[title="Copy"]') as HTMLDivElement;
@@ -39,11 +77,22 @@ describe('CodeBlock', () => {
       html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
     );
 
-    const code = getCode(mounted);
-    expect(code).toBeTruthy();
-    expect(code.textContent).toBe('SELECT 1;');
-    expect(code.querySelector('pre.shiki')).toBeNull();
-    expect(code.style.backgroundColor).toBe('');
+    const preview = getPreview(mounted);
+    expect(preview).toBeTruthy();
+    expect(preview.textContent).toBe('SELECT 1;');
+    expect(preview.querySelector('pre.shiki')).toBeNull();
+    expect(getScroller(mounted).style.backgroundColor).toBe('');
+  });
+
+  it('commits the unhighlighted value as text, so both layers hold the same characters', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'List<String> ids;'} lang=${'java'} />`
+    );
+
+    const preview = getPreview(mounted);
+    expect(preview.textContent).toBe('List<String> ids;');
+    expect(preview.children).toHaveLength(0);
+    expect(getTextarea(mounted).value).toBe('List<String> ids;');
   });
 
   it('renders the copy affordance with the far/copy icon', async () => {
@@ -55,6 +104,155 @@ describe('CodeBlock', () => {
     expect(clipboard).toBeTruthy();
     expect(clipboard.querySelector('svg')).toBeTruthy();
     expect(getRoot(mounted).contains(clipboard)).toBe(true);
+  });
+
+  it('overlays the preview with a textarea carrying the raw value', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const textarea = getTextarea(mounted);
+    expect(textarea).toBeTruthy();
+    expect(textarea.disabled).toBe(false);
+    expect(textarea.value).toBe('SELECT 1;');
+    expect(textarea.previousElementSibling).toBe(getPreview(mounted));
+  });
+
+  it('stays focusable and caret-bearing rather than readonly, which Chrome paints no caret in', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const textarea = getTextarea(mounted);
+    expect(textarea.readOnly).toBe(false);
+    expect(textarea.hasAttribute('readonly')).toBe(false);
+    expect(textarea.getAttribute('aria-readonly')).toBe('true');
+    expect(textarea.getAttribute('tabindex')).toBe('0');
+    expect(textarea.getAttribute('inputmode')).toBe('none');
+    expect(textarea.getAttribute('spellcheck')).toBe('false');
+    expect(textarea.getAttribute('autocorrect')).toBe('off');
+    expect(textarea.getAttribute('autocapitalize')).toBe('off');
+    expect(textarea.getAttribute('autocomplete')).toBe('off');
+  });
+
+  it('refuses every edit the now-editable overlay could otherwise take', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const textarea = getTextarea(mounted);
+    const beforeinput = new Event('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+    });
+    textarea.dispatchEvent(beforeinput);
+    expect(beforeinput.defaultPrevented).toBe(true);
+
+    // the composition paths that are not cancelable land here instead
+    textarea.value = 'DROP TABLE users;';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    await flush();
+    expect(textarea.value).toBe('SELECT 1;');
+  });
+
+  it('keeps a paste inside the overlay, away from the editor root that would act on it', async () => {
+    const onRootPaste = vi.fn();
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+    mounted.container.addEventListener('paste', onRootPaste);
+
+    const paste = new Event('paste', { bubbles: true, cancelable: true });
+    getTextarea(mounted).dispatchEvent(paste);
+
+    expect(paste.defaultPrevented).toBe(true);
+    expect(onRootPaste).not.toHaveBeenCalled();
+  });
+
+  it('names the overlay, which is the only thing left in the accessibility tree', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    expect(getTextarea(mounted).getAttribute('aria-label')).toBe('Code');
+    expect(getPreview(mounted).getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('strips the trailing newline, which a textarea turns into a line the preview has not got', async () => {
+    const { service, codeToHtml } = createShikiService();
+    setGetShikiServiceCallback(() => service);
+    const onCopy = vi.fn();
+
+    mounted = await mountAndFlush(
+      html`<${CodeBlock}
+        value=${'SELECT 1;\nSELECT 2;\n'}
+        lang=${'sql'}
+        .onCopy=${onCopy}
+      />`
+    );
+
+    expect(getTextarea(mounted).value).toBe('SELECT 1;\nSELECT 2;');
+    expect(codeToHtml).toHaveBeenCalledWith('SELECT 1;\nSELECT 2;', {
+      lang: 'sql',
+      theme: undefined,
+    });
+
+    getClipboard(mounted).dispatchEvent(
+      new MouseEvent('click', { bubbles: true })
+    );
+    await flush();
+
+    expect(onCopy).toHaveBeenCalledWith('SELECT 1;\nSELECT 2;');
+  });
+
+  it('keeps the unhighlighted preview on the same characters as the overlay', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;\n\n'} lang=${'sql'} />`
+    );
+
+    expect(getPreview(mounted).textContent).toBe('SELECT 1;');
+    expect(getTextarea(mounted).value).toBe('SELECT 1;');
+  });
+
+  it('nests the two layers inside the one scroll container', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const root = getRoot(mounted);
+    const scroller = getScroller(mounted);
+    const layers = getLayers(mounted);
+
+    expect(scroller.parentElement).toBe(root);
+    expect(layers.parentElement).toBe(scroller);
+    expect(getPreview(mounted).parentElement).toBe(layers);
+    expect(getTextarea(mounted).parentElement).toBe(layers);
+    // the clipboard button sits outside the scroller, last, so it stays pinned and on top
+    expect(root.lastElementChild).toBe(getClipboard(mounted));
+    expect(scroller.contains(getClipboard(mounted))).toBe(false);
+  });
+
+  it('opts only the scroller into the scrollbar hook, never the overlay', async () => {
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    expect(getScroller(mounted).classList.contains('scrollbar')).toBe(true);
+    expect(getTextarea(mounted).classList.contains('scrollbar')).toBe(false);
+    expect(getPreview(mounted).classList.contains('scrollbar')).toBe(false);
+    expect(mounted.container.querySelectorAll('.scrollbar')).toHaveLength(1);
+  });
+
+  it('keeps the textarea on the raw value once the highlight lands', async () => {
+    const { service } = createShikiService();
+    setGetShikiServiceCallback(() => service);
+
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
+    expect(getTextarea(mounted).value).toBe('SELECT 1;');
   });
 
   it('highlights through the shiki service and adopts its background color', async () => {
@@ -70,11 +268,29 @@ describe('CodeBlock', () => {
       theme: 'dark',
     });
 
-    const code = getCode(mounted);
-    const pre = code.querySelector('pre.shiki') as HTMLPreElement;
+    const pre = getPreview(mounted).querySelector(
+      'pre.shiki'
+    ) as HTMLPreElement;
     expect(pre).toBeTruthy();
     expect(pre.style.backgroundColor).not.toBe('');
-    expect(code.style.backgroundColor).toBe(pre.style.backgroundColor);
+    expect(getScroller(mounted).style.backgroundColor).toBe(
+      pre.style.backgroundColor
+    );
+  });
+
+  it('drops the tab stop shiki puts on its pre', async () => {
+    const { service } = createShikiService();
+    setGetShikiServiceCallback(() => service);
+
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const pre = getPreview(mounted).querySelector(
+      'pre.shiki'
+    ) as HTMLPreElement;
+    expect(pre).toBeTruthy();
+    expect(pre.hasAttribute('tabindex')).toBe(false);
   });
 
   it('leaves the background color empty when the highlight has no pre.shiki', async () => {
@@ -87,9 +303,8 @@ describe('CodeBlock', () => {
       html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
     );
 
-    const code = getCode(mounted);
-    expect(code.querySelector('.plain')).toBeTruthy();
-    expect(code.style.backgroundColor).toBe('');
+    expect(getPreview(mounted).querySelector('.plain')).toBeTruthy();
+    expect(getScroller(mounted).style.backgroundColor).toBe('');
   });
 
   it('leaves the background color empty when pre.shiki carries no background', async () => {
@@ -102,9 +317,39 @@ describe('CodeBlock', () => {
       html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
     );
 
-    const code = getCode(mounted);
-    expect(code.querySelector('pre.shiki')).toBeTruthy();
-    expect(code.style.backgroundColor).toBe('');
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
+    expect(getScroller(mounted).style.backgroundColor).toBe('');
+  });
+
+  it('registers no scroll listener, because the scroller carries both layers', async () => {
+    const { service } = createShikiService();
+    setGetShikiServiceCallback(() => service);
+
+    const addEventListener = vi.spyOn(
+      HTMLTextAreaElement.prototype,
+      'addEventListener'
+    );
+
+    mounted = await mountAndFlush(
+      html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
+    );
+
+    const textarea = getTextarea(mounted);
+    const scrollRegistrations = addEventListener.mock.calls.filter(
+      ([type]) => type === 'scroll'
+    );
+    addEventListener.mockRestore();
+    expect(scrollRegistrations).toEqual([]);
+
+    // a sync listener would only be observable from a non-zero offset, so give it one
+    textarea.scrollTop = 42;
+    textarea.scrollLeft = 42;
+    textarea.dispatchEvent(new Event('scroll'));
+    await flush();
+
+    const preview = getPreview(mounted);
+    expect(preview.scrollTop).toBe(0);
+    expect(preview.scrollLeft).toBe(0);
   });
 
   it('calls onCopy with the current value when the clipboard button is clicked', async () => {
@@ -163,6 +408,7 @@ describe('CodeBlock', () => {
     await flush();
     expect(codeToHtml.mock.calls.length).toBe(initialCalls + 1);
     expect(codeToHtml.mock.calls.at(-1)?.[0]).toBe('SELECT 2;');
+    expect(getTextarea(mounted).value).toBe('SELECT 2;');
 
     state.theme = 'light';
     await flush();
@@ -178,21 +424,78 @@ describe('CodeBlock', () => {
     expect(codeToHtml.mock.calls.length).toBe(callsBeforeUnwatched);
   });
 
+  it('drops the stale highlight the moment the value changes, so both layers hold one text', async () => {
+    const { state, deferred, Pending } = pendingHighlight();
+
+    mounted = await mountAndFlush(html`<${Pending} />`);
+    deferred[0](HIGHLIGHT);
+    await flush();
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
+
+    state.value = 'SELECT 2;\nSELECT 3;';
+    await flush();
+
+    const preview = getPreview(mounted);
+    expect(preview.querySelector('pre.shiki')).toBeNull();
+    expect(preview.textContent).toBe('SELECT 2;\nSELECT 3;');
+    expect(getTextarea(mounted).value).toBe('SELECT 2;\nSELECT 3;');
+
+    deferred[1](HIGHLIGHT);
+    await flush();
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
+  });
+
+  it('keeps the highlight through a theme change, which moves no glyph', async () => {
+    const { state, deferred, Pending } = pendingHighlight();
+
+    mounted = await mountAndFlush(html`<${Pending} />`);
+    deferred[0](HIGHLIGHT);
+    await flush();
+
+    state.theme = 'light';
+    await flush();
+
+    expect(deferred).toHaveLength(2);
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
+  });
+
+  it('ignores a highlight a newer request has already superseded', async () => {
+    const { state, deferred, Pending } = pendingHighlight();
+
+    mounted = await mountAndFlush(html`<${Pending} />`);
+    state.value = 'SELECT 2;';
+    await flush();
+    expect(deferred).toHaveLength(2);
+
+    deferred[1](
+      '<pre class="shiki"><code class="fresh">SELECT 2;</code></pre>'
+    );
+    await flush();
+    deferred[0](
+      '<pre class="shiki"><code class="stale">SELECT 1;</code></pre>'
+    );
+    await flush();
+
+    const preview = getPreview(mounted);
+    expect(preview.querySelector('.fresh')).toBeTruthy();
+    expect(preview.querySelector('.stale')).toBeNull();
+  });
+
   it('re-highlights when the shiki service loads after mount', async () => {
     mounted = await mountAndFlush(
       html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
     );
-    expect(getCode(mounted).querySelector('pre.shiki')).toBeNull();
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeNull();
 
     const { service, codeToHtml } = createShikiService();
     setGetShikiServiceCallback(() => service);
     await flush();
 
     expect(codeToHtml).toHaveBeenCalledTimes(1);
-    expect(getCode(mounted).querySelector('pre.shiki')).toBeTruthy();
+    expect(getPreview(mounted).querySelector('pre.shiki')).toBeTruthy();
   });
 
-  it('tolerates a highlight resolving after unmount, once the root ref is released', async () => {
+  it('tolerates a highlight resolving after unmount, once the preview ref is released', async () => {
     let resolveHighlight: (value: string) => void = () => {};
     const codeToHtml = vi.fn(
       () =>
@@ -207,7 +510,7 @@ describe('CodeBlock', () => {
     mounted = await mountAndFlush(
       html`<${CodeBlock} value=${'SELECT 1;'} lang=${'sql'} />`
     );
-    const code = getCode(mounted);
+    const scroller = getScroller(mounted);
     const root = getRoot(mounted);
     expect(codeToHtml).toHaveBeenCalledTimes(1);
 
@@ -217,9 +520,9 @@ describe('CodeBlock', () => {
     resolveHighlight(HIGHLIGHT);
     await flush();
 
-    // the ref directive nulls `root.value` on destroy, so `getBackgroundColor`
-    // bails out and no background color is ever committed to the detached node
-    expect(code.style.backgroundColor).toBe('');
+    // the ref directive nulls `preview.value` on destroy, so `getPre` bails out and the background
+    // color is never committed to the detached node
+    expect(scroller.style.backgroundColor).toBe('');
     expect(root.isConnected).toBe(false);
   });
 

--- a/packages/erd-editor/src/components/primitives/code-block/CodeBlock.tsx
+++ b/packages/erd-editor/src/components/primitives/code-block/CodeBlock.tsx
@@ -31,7 +31,7 @@ export type CodeBlockProps = {
 };
 
 const CodeBlock: FC<CodeBlockProps> = (props, ctx) => {
-  const root = createRef<HTMLDivElement>();
+  const preview = createRef<HTMLDivElement>();
   const { addUnsubscribe } = useUnmounted();
 
   const state = observable({
@@ -39,15 +39,48 @@ const CodeBlock: FC<CodeBlockProps> = (props, ctx) => {
     backgroundColor: '',
   });
 
+  let highlightSource: string | null = null;
+  let highlightRequestId = 0;
+
+  // a trailing break is a real last line in a textarea and no line box in the preview
+  const getValue = () => props.value.replace(/\n+$/, '');
+
   const handleCopy = () => {
-    props.onCopy?.(props.value);
+    props.onCopy?.(getValue());
+  };
+
+  /*
+   * The overlay refuses edits here rather than through `readonly`, which Chrome paints no caret in.
+   * `input` covers the composition paths `beforeinput` cannot cancel.
+   */
+  const handleBeforeinput = (event: Event) => {
+    event.preventDefault();
+  };
+
+  const handleInput = (event: Event) => {
+    const $textarea = event.target as HTMLTextAreaElement;
+    const value = getValue();
+
+    if ($textarea.value !== value) {
+      $textarea.value = value;
+    }
+  };
+
+  // the editor root turns a `paste` that reaches it into a diagram-level action
+  const handlePaste = (event: ClipboardEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const getPre = () => {
+    const $preview = preview.value;
+    if (!$preview) return null;
+
+    return $preview.querySelector('pre.shiki') as HTMLPreElement | null;
   };
 
   const getBackgroundColor = () => {
-    const $root = root.value;
-    if (!$root) return null;
-
-    const pre = $root.querySelector('pre.shiki') as HTMLPreElement | null;
+    const pre = getPre();
     if (!pre) return null;
 
     const backgroundColor = pre.style.backgroundColor;
@@ -59,16 +92,29 @@ const CodeBlock: FC<CodeBlockProps> = (props, ctx) => {
   const setBackgroundColor = () => {
     nextTick(() => {
       state.backgroundColor = getBackgroundColor() || '';
+      // shiki ships `tabindex="0"`, a tab stop inside the aria-hidden preview
+      getPre()?.removeAttribute('tabindex');
     });
   };
 
   const setHighlight = () => {
+    const value = getValue();
+    const requestId = ++highlightRequestId;
+
+    // the overlay commits the new value on the next render; stale markup would outlive it
+    if (highlightSource !== value) {
+      highlightSource = value;
+      state.highlight = '';
+    }
+
     getShikiService()
-      ?.codeToHtml(props.value, {
+      ?.codeToHtml(value, {
         lang: props.lang,
         theme: props.theme,
       })
       .then(highlight => {
+        if (requestId !== highlightRequestId) return;
+
         state.highlight = highlight;
         setBackgroundColor();
       });
@@ -88,21 +134,48 @@ const CodeBlock: FC<CodeBlockProps> = (props, ctx) => {
     );
   });
 
-  return () => (
-    <div class={styles.root} use:ref={ref(root)}>
-      <div
-        class={['scrollbar', styles.code]}
-        style={{
-          'background-color': state.backgroundColor,
-        }}
-      >
-        {innerHTML(state.highlight ? state.highlight : props.value)}
+  return () => {
+    const value = getValue();
+
+    return (
+      <div class={styles.root}>
+        <div
+          class={['scrollbar', styles.scroller]}
+          style={{
+            'background-color': state.backgroundColor,
+          }}
+        >
+          <div class={styles.layers}>
+            <div
+              class={styles.preview}
+              aria-hidden="true"
+              use:ref={ref(preview)}
+            >
+              {state.highlight ? innerHTML(state.highlight) : value}
+            </div>
+            <textarea
+              class={styles.textarea}
+              aria-label="Code"
+              aria-readonly="true"
+              inputmode="none"
+              tabindex="0"
+              spellcheck="false"
+              autocorrect="off"
+              autocapitalize="off"
+              autocomplete="off"
+              prop:value={value}
+              on:beforeinput={handleBeforeinput}
+              on:input={handleInput}
+              on:paste={handlePaste}
+            ></textarea>
+          </div>
+        </div>
+        <div class={styles.clipboard} title="Copy" on:click={handleCopy}>
+          <Icon prefix="far" name="copy" useTransition={true} />
+        </div>
       </div>
-      <div class={styles.clipboard} title="Copy" on:click={handleCopy}>
-        <Icon prefix="far" name="copy" useTransition={true} />
-      </div>
-    </div>
-  );
+    );
+  };
 };
 
 export default CodeBlock;

--- a/packages/erd-editor/src/styles/emittedCss.regression.test.ts
+++ b/packages/erd-editor/src/styles/emittedCss.regression.test.ts
@@ -185,15 +185,17 @@ describe('rule-count invariance', () => {
     expect(modulePaths).toHaveLength(62);
   });
 
-  it('adopts 611 rules, none of them a duplicate', () => {
+  it('adopts 617 rules, none of them a duplicate', () => {
     // 302 -> 609: the color picker fold, +307. It rendered into a tree `<style>` before, so none
     // of its rules were adopted and none of them were counted here; as a `css.global` literal all
-    // 307 are. 609 -> 611: the Alt+drag ghost's two scoped rules.
-    expect(cumulative).toHaveLength(611);
-    expect(new Set(cumulative).size).toBe(611);
+    // 307 are. 609 -> 611: the Alt+drag ghost's two scoped rules. 611 -> 617: the CodeBlock
+    // overlay, which splits its one `code` rule into a shared alignment fragment, a scroller, a
+    // layer box, a preview and its `*` block, and a textarea with its `::selection`.
+    expect(cumulative).toHaveLength(617);
+    expect(new Set(cumulative).size).toBe(617);
   });
 
-  it('splits into 327 global rules ahead of 284 component rules', () => {
+  it('splits into 327 global rules ahead of 290 component rules', () => {
     // P4 moved reset (12), fonts (1), typography (1) and scrollbar (6) out of tree `<style>`
     // elements and into `adoptedStyleSheets`. A shadow root applies its own `styleSheets` before
     // its `adoptedStyleSheets`, so the only thing keeping the reset ahead of the components now
@@ -204,10 +206,11 @@ describe('rule-count invariance', () => {
     // says the fold moved a sheet between pools rather than rewriting one. The component half
     // then went 158 -> 160 sheets and 282 -> 284 rules on its own account, when the Alt+drag
     // ghost added its layer and per-entity templates; the global half did not move with it,
-    // which is the same statement in the other direction.
-    expect(sheetsOfEachKind).toEqual({ global: 5, component: 160 });
+    // which is the same statement in the other direction. 160 -> 164 sheets / 284 -> 290 rules is
+    // the CodeBlock overlay, on the same terms.
+    expect(sheetsOfEachKind).toEqual({ global: 5, component: 164 });
     expect(globalRules).toHaveLength(327);
-    expect(componentRules).toHaveLength(284);
+    expect(componentRules).toHaveLength(290);
     expect(cumulative).toEqual([...globalRules, ...componentRules]);
   });
 
@@ -224,7 +227,7 @@ describe('rule-count invariance', () => {
     // Identifiers are content hashes now, so a rule's text is the same whether its module is
     // rendered alone or with the other 61 — which is exactly what makes this comparison mean
     // "nothing was lost to dedup" rather than "the class names differ".
-    expect(union.size).toBe(611);
+    expect(union.size).toBe(617);
     expect(droppedByLoadingTogether).toEqual([]);
   });
 
@@ -242,7 +245,7 @@ describe('rule-count invariance', () => {
 
 describe('empty rules', () => {
   it('discards the two rules whose bodies were empty, keeping their children', () => {
-    // `ErdEditor.styles.ts:17` `&.none-focus` and `CodeBlock.styles.ts:30` `&:hover` hold nested
+    // `ErdEditor.styles.ts:17` `&.none-focus` and `CodeBlock.styles.ts:59` `&:hover` hold nested
     // rules and no declarations of their own. The old pipeline emitted `.S.none-focus {  }` and
     // `.S:hover {  }`; the compiler discards a rule with no declarations.
     expect(cumulative.filter(text => /\{\s*\}$/.test(text))).toEqual([]);

--- a/packages/erd-editor/src/themes/radix-ui-theme.config.test.ts
+++ b/packages/erd-editor/src/themes/radix-ui-theme.config.test.ts
@@ -13,6 +13,11 @@ describe('ThemeConfig', () => {
     expect(entries).toHaveLength(65);
   });
 
+  it('keeps placeholder on an alpha scale, which CodeBlock paints its selection band from', () => {
+    // the band is painted over the highlighted code, so an opaque value would hide what it selects
+    expect(ThemeConfig.placeholder).toMatch(/^grayA-/);
+  });
+
   it('maps every gray/accent scale token onto its own scale step', () => {
     for (let step = 1; step <= 12; step++) {
       expect(get(ThemeConfig, `grayColor${step}`)).toBe(`gray-${step}`);

--- a/packages/r-html/src/jsx-runtime.ts
+++ b/packages/r-html/src/jsx-runtime.ts
@@ -107,9 +107,21 @@ export interface CommonAttributes extends Sigils, DatasetAttributes {
 
 export interface HTMLAttributes
   extends CommonAttributes, EventHandlers<HTMLElementEventMap> {
+  /** Global, and enumerated: the values are the strings. */
+  autocapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
   /** Enumerated, like `spellcheck`: the values are the strings. */
   draggable?: boolean | 'true' | 'false';
   hidden?: boolean;
+  /** Global, and enumerated: `none` keeps a focusable field from raising a keyboard. */
+  inputmode?:
+    | 'none'
+    | 'text'
+    | 'decimal'
+    | 'numeric'
+    | 'tel'
+    | 'search'
+    | 'email'
+    | 'url';
   role?: string;
   /** An enumerated attribute, not a boolean one: the values are the strings. */
   spellcheck?: boolean | 'true' | 'false';
@@ -161,6 +173,9 @@ export interface InputAttributes extends HTMLAttributes {
 }
 
 export interface TextareaAttributes extends HTMLAttributes {
+  autocomplete?: string;
+  /** WebKit's, and enumerated: the values are the strings. */
+  autocorrect?: 'on' | 'off';
   cols?: number;
   disabled?: boolean;
   name?: string;

--- a/packages/r-html/src/template/cssSource.test.ts
+++ b/packages/r-html/src/template/cssSource.test.ts
@@ -53,7 +53,7 @@ describe('classifySlots', () => {
   });
 
   it('reads a selector site as inline', () => {
-    // `CodeBlock.styles.ts:31` — `${clipboard} {`
+    // `CodeBlock.styles.ts:60` — `${clipboard} {`
     expect(kindsOf('\n  ', ' {\n    opacity: 1;\n  }\n')).toEqual(['inline']);
     // `css.test.ts` — `.wrap ${child} {`
     expect(kindsOf('\n  .wrap ', ' {\n    color: pink;\n  }\n')).toEqual([


### PR DESCRIPTION
Copying out of the **Schema SQL** and **Generator Code** panels meant dragging over shiki's markup: Ctrl+A selected the whole page, and the clipboard carried the highlighter's spans rather than the code.

A transparent `<textarea>` now sits on top of the highlighted preview — the OverType technique. Selection, Ctrl+A, Ctrl+C and mobile long-press are all native and operate on the exact value, while the syntax colours stay visible underneath.

## One scroll container, not two

The obvious shape is two overlapping scrollers with their offsets mirrored in JavaScript. This does not do that. The two layers are siblings inside a single scroller, `.layers` is sized by the preview, and the overlay is stretched onto it — so the overlay has no scroll of its own to desync:

```
.root         position: relative; overflow: hidden      ← copy button, pinned
└─ .scroller  overflow: auto                            ← the only scroller
   └─ .layers position: relative; width: max-content;
              min-width: 100%; min-height: 100%         ← sized by the preview
      ├─ .preview   in-flow, shiki markup
      └─ textarea   position: absolute; inset: 0; overflow: hidden
```

That removes two bug classes rather than managing them:

- Reassigning `prop:value` resets a scrolling textarea to offset 0 **without firing a scroll event**, so a JS mirror silently desyncs on every value change.
- A textarea and a block container disagree about whether `padding-right` counts toward `scrollWidth`, so a JS mirror drifts at the far edge of horizontal scroll.

Verified in Chromium, Firefox and WebKit that the outer scroller — never the overlay — takes drag-select autoscroll and caret-reveal, and that both layers' `getBoundingClientRect()` agree to the subpixel.

## Editable, not `readonly`

Chrome paints no caret in a `readonly` field, and the caret is the only cue for where a selection starts when the text itself is transparent. So the overlay stays editable and refuses edits instead: `beforeinput` cancels every mutation, `input` covers the composition paths that are not cancelable, and `inputmode="none"` keeps the soft keyboard down.

## Defects found on the way

| | |
|---|---|
| **`innerHTML` fallback** | The unhighlighted fallback committed `props.value` through `innerHTML`, so code containing `<` or `&` — Java's `List<String>` — was parsed as markup. The preview lost characters the overlay still had, landing selections on the wrong glyphs. Commits as a text node now. |
| **`font-family` never reached shiki** | It was set on the container with `!important`, but the UA matches `pre` and `code` *directly*, and a directly matched declaration beats an inherited one at any specificity. Under an overlay that is guaranteed misalignment. |
| **Paste guard asymmetry** (separate commit) | `handleCopy` has read the event target since AC-32; `handlePaste` never got the same guard, so pasting text into a **memo** merged it into the selected tables as new columns. Pre-existing, and independent of this feature. |

## Notes for review

- `onCopy` now receives the value with its trailing newline stripped. Generators end their output with one, which is a real last line in a textarea and no line box in a block container, so it is stripped before either layer sees it.
- `::selection` is painted from `--placeholder` (`grayA-10`, ~0.46 alpha) — the only existing theme token with enough alpha to read as a selection band without hiding the code beneath it. A `setTheme` caller passing an opaque placeholder would get an unreadable band; a guard test pins the token to the `grayA-*` scale, but a dedicated `selectionBackground` token was deliberately not added rather than widen the published theme API.
- No focus ring. The overlay is a tab stop whose only visual cue is the caret.
- **No Playwright coverage.** happy-dom has no layout engine, so the alignment and autoscroll facts above are unreachable from the unit suite and were verified out-of-band; `packages/erd-editor/e2e/specs/` has no CodeBlock spec. A layout regression here would ship silently.

## Verification

`pnpm check`, `pnpm test` and `pnpm build` all pass. `erd-editor` is 349 files / 5873 tests, run with `--no-cache` — Vite+ task caching replays stored stdout at 100% cache hit, which is indistinguishable from a real pass.

The three new paste-guard tests were confirmed falsifiable: with the guard removed they fail, and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
