### PR TITLE
feat: Show a collaborator's focus, selection and drag box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,26 @@
 name: ci
 
 on:
-  - workflow_dispatch
-  - push
-  - pull_request
+  workflow_dispatch:
+  # `push` is main-only and `pull_request` covers everything else, so a branch
+  # with an open PR runs once rather than twice. Dropping `pull_request` instead
+  # would be cheaper still and is wrong: a fork's branch push runs in the fork's
+  # own Actions, so external contributions — 12 of the last 60 PRs — would arrive
+  # here with no checks at all. `pull_request` also tests the merge commit, which
+  # is what catches a branch that is green alone and broken against current main.
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Superseding a PR's run is free — the older commit is not what anyone will
+# merge. A main run is not: cancelling it leaves the commit that was pushed
+# first unverified, which is why `cancel-in-progress` is an expression rather
+# than `true` and why `intellij-plugin.yml`, whose block is unconditional, stays
+# a separate workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Style and types. This is the only place they are enforced for everyone: the

--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -9,9 +9,11 @@
 name: intellij-plugin
 
 on:
-  - workflow_dispatch
-  - push
-  - pull_request
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 .nx
 .omc
 .omx
+.omo
 .playwright-mcp
 
 # Playwright

--- a/erd-editor.code-workspace
+++ b/erd-editor.code-workspace
@@ -62,26 +62,11 @@
     },
   ],
   "settings": {
-    // Editor and CLI run the same rules, and not by coincidence: Vite+ installs
-    // `oxlint` and `oxfmt` shims into `node_modules/.bin` whose only purpose is
-    // to let this extension discover and start their LSP servers, and those
-    // shims load the root `vite.config.ts` before handing off. So the `lint`
-    // and `fmt` blocks there are the single source of truth for both — there is
-    // deliberately no `.oxlintrc.json` or `.oxfmtrc.json` in this repo, and
-    // adding one would give the editor a second, competing answer.
     "editor.formatOnSave": true,
-    // oxfmt formats whole files. The default, "modifications", would hand it
-    // only the changed ranges and produce output `vp fmt` disagrees with.
     "editor.formatOnSaveMode": "file",
     "editor.codeActionsOnSave": {
       "source.fixAll.oxc": "explicit",
     },
-    // Named per language rather than globally. oxfmt honours the root
-    // `fmt.ignorePatterns`, which denies json/css/markdown/js among others, and
-    // for those it returns the buffer untouched — as the *default* formatter
-    // that reads to the editor as "formatting did nothing" while displacing
-    // VSCode's own built-ins. So it is declared only for what it actually
-    // formats: `.ts`/`.mts` (typescript) and `.tsx` (typescriptreact).
     "[typescript]": {
       "editor.defaultFormatter": "oxc.oxc-vscode",
     },

--- a/packages/app/src/atoms/modules/sidebar/index.ts
+++ b/packages/app/src/atoms/modules/sidebar/index.ts
@@ -49,12 +49,14 @@ const replicationSchemaEntityAtom = atom(
       replicationSchemaEntityAction({
         id,
         actions: actions.filter(
-          (action: any) => action.type !== 'editor.sharedMouseTracker'
+          (action: any) =>
+            action.type !== 'editor.sharedMouseTracker' &&
+            action.type !== 'editor.sharedFocusTracker'
         ),
       })
     );
 
-    // Peers get the unfiltered stream — shared cursors are part of the session
+    // Peers get the unfiltered stream — shared presence is part of the session
     // even though they are noise for the cross-tab replica. Only the tab holding
     // the leadership lock owns the peer connections, so everyone else has to hand
     // the batch over the bridge.

--- a/packages/erd-editor/README.md
+++ b/packages/erd-editor/README.md
@@ -120,7 +120,7 @@ erd-editor {
 | `setPresetTheme(options)` | Set `appearance`, `grayColor` and `accentColor`. |
 | `setTheme(theme)` | Override individual theme tokens. |
 | `setKeyBindingMap(map)` | Remap shortcuts. `edit`, `stop`, `search`, `undo`, `redo`, `zoomIn` and `zoomOut` are reserved. |
-| `getSharedStore(config?)` | Returns `{ subscribe, dispatch, dispatchSync, connection, disconnect, destroy }`. `subscribe` gives you this editor's actions to relay; `dispatch` applies a peer's. You supply the transport. `config` is `{ getNickname?, mouseTracker? }`. |
+| `getSharedStore(config?)` | Returns `{ subscribe, dispatch, dispatchSync, connection, disconnect, destroy }`. `subscribe` gives you this editor's actions to relay; `dispatch` applies a peer's. You supply the transport. `config` is `{ getNickname?, mouseTracker?, focusTracker? }`; both trackers default to `true` and broadcast this editor's cursor and table focus to peers. |
 | `focus()` / `blur()` | Move focus in and out of the editor. |
 | `clear()` | Empty the document. |
 | `destroy()` | Tear the editor down and release its listeners, subscriptions and shared stores. |

--- a/packages/erd-editor/e2e/specs/shared-presence.spec.ts
+++ b/packages/erd-editor/e2e/specs/shared-presence.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from '../support/fixtures';
+import { twoTables } from '../support/schema';
+
+/**
+ * Collaborative presence, driven through the real transport: a second
+ * `<erd-editor>` on the page, cross-wired to the first through `getSharedStore`.
+ *
+ * Unit tests cover the action, the reducer and the attributes in isolation.
+ * What only a real pair can show is that a burst of focus changes leaves the
+ * peer on the cell the user actually stopped on — the shared stream compresses
+ * bursts, and a leading-only throttle strands the last one forever.
+ */
+const PEER = '#peer erd-editor';
+const LOCAL = '#app erd-editor';
+
+async function attachPeer(page: import('@playwright/test').Page) {
+  await page.evaluate(async () => {
+    const local = document.querySelector('erd-editor')!;
+    const host = document.createElement('div');
+    host.id = 'peer';
+    host.setAttribute(
+      'style',
+      'position:fixed;left:0;top:0;width:900px;height:600px;visibility:hidden'
+    );
+    document.body.appendChild(host);
+
+    const peer = document.createElement('erd-editor');
+    peer.systemDarkMode = false;
+    peer.setAttribute('style', 'display:block;width:100%;height:100%');
+    host.appendChild(peer);
+    peer.setInitialValue(local.value);
+
+    const local$ = local.getSharedStore();
+    const peer$ = peer.getSharedStore();
+    local$.subscribe(actions => peer$.dispatch(actions));
+    peer$.subscribe(actions => local$.dispatch(actions));
+  });
+}
+
+test.describe('shared presence', () => {
+  test('a peer focus outlines the table and underlines the cell', async ({
+    erd,
+    page,
+  }) => {
+    await erd.seed(twoTables());
+    await attachPeer(page);
+
+    const peerCell = page
+      .locator(PEER)
+      .locator('[data-testid="erd-canvas"] .table')
+      .first()
+      .locator('.column-col[data-type="columnName"]')
+      .first();
+    await peerCell.dispatchEvent('mousedown');
+
+    const marked = page
+      .locator(LOCAL)
+      .locator('[data-testid="erd-canvas"] .table[data-shared-focus]');
+    await expect(marked).toHaveCount(1);
+    await expect(marked.locator('.column-col[data-shared-focus]')).toHaveCount(
+      1
+    );
+
+    await page
+      .locator(PEER)
+      .locator('[data-testid="erd-canvas"]')
+      .dispatchEvent('mousedown');
+    await expect(
+      page.locator(LOCAL).locator('[data-shared-focus]')
+    ).toHaveCount(0);
+  });
+
+  test('the last focus of a burst is the one the peer ends up showing', async ({
+    erd,
+    page,
+  }) => {
+    await erd.seed(twoTables());
+    await attachPeer(page);
+
+    const cells = page
+      .locator(PEER)
+      .locator('[data-testid="erd-canvas"] .table')
+      .first()
+      .locator('.column-col[data-type="columnName"]');
+    const count = await cells.count();
+    expect(count).toBeGreaterThan(1);
+
+    // Faster than the 100ms shared-stream window, so every step but the last is
+    // compressed away.
+    for (let index = 0; index < count; index++) {
+      await cells.nth(index).dispatchEvent('mousedown');
+      await page.waitForTimeout(30);
+    }
+    const expected = (await cells.nth(count - 1).textContent())?.trim();
+
+    await expect(
+      page
+        .locator(LOCAL)
+        .locator('[data-testid="erd-canvas"] .column-col[data-shared-focus]')
+    ).toHaveText(expected!);
+  });
+
+  test('a peer multi-select rings every table it holds', async ({
+    erd,
+    page,
+  }) => {
+    await erd.seed(twoTables());
+    await attachPeer(page);
+
+    await page.evaluate(() => {
+      const peer = document.querySelector<HTMLElement>('#peer erd-editor')!;
+      const tables = [
+        ...peer.shadowRoot!.querySelectorAll<HTMLElement>(
+          '[data-testid="erd-canvas"] .table'
+        ),
+      ];
+
+      tables.forEach((table, index) =>
+        table.dispatchEvent(
+          new MouseEvent('mousedown', {
+            bubbles: true,
+            metaKey: index > 0,
+            ctrlKey: index > 0,
+          })
+        )
+      );
+    });
+
+    const rung = page
+      .locator(LOCAL)
+      .locator('[data-testid="erd-canvas"] .table[data-shared-select]');
+    await expect(rung).toHaveCount(2);
+
+    const colors = await rung.evaluateAll(elements =>
+      elements.map(el =>
+        (el as HTMLElement).style.getPropertyValue('--shared-select')
+      )
+    );
+    expect(new Set(colors).size).toBe(1);
+    expect(colors[0]).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  test('a peer drag box is drawn while the drag is live and gone after it ends', async ({
+    erd,
+    page,
+  }) => {
+    await erd.seed(twoTables());
+    await attachPeer(page);
+
+    const drag = (type: string, x: number, y: number) =>
+      page.evaluate(
+        ({ type, x, y }) => {
+          const peer = document.querySelector<HTMLElement>('#peer erd-editor')!;
+          const canvas = peer.shadowRoot!.querySelector(
+            '[data-testid="erd-canvas"]'
+          ) as HTMLElement;
+          canvas.dispatchEvent(
+            new MouseEvent(type, {
+              bubbles: true,
+              clientX: x,
+              clientY: y,
+              metaKey: true,
+              ctrlKey: true,
+            })
+          );
+        },
+        { type, x, y }
+      );
+
+    await drag('mousedown', 40, 40);
+    await drag('mousemove', 600, 400);
+
+    const box = page
+      .locator(LOCAL)
+      .locator('[data-testid="shared-drag-select"]');
+    await expect(box).toHaveCount(1);
+    await expect(box).toHaveAttribute('style', /stroke: /);
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    await expect(box).toHaveCount(0);
+  });
+});

--- a/packages/erd-editor/src/components/erd-editor/ErdEditor.tsx
+++ b/packages/erd-editor/src/components/erd-editor/ErdEditor.tsx
@@ -88,7 +88,10 @@ export interface ErdEditorElement extends ErdEditorProps, HTMLElement {
   setSchemaAML: (value: string) => void;
   getSchemaSQL: (databaseVendor?: DatabaseVendor) => string;
   getSharedStore: (
-    config?: SharedStoreConfig & { mouseTracker?: boolean }
+    config?: SharedStoreConfig & {
+      mouseTracker?: boolean;
+      focusTracker?: boolean;
+    }
   ) => SharedStore;
   setDiffValue: (value: string) => void;
 }

--- a/packages/erd-editor/src/components/erd-editor/useErdEditorAttachElement.test.ts
+++ b/packages/erd-editor/src/components/erd-editor/useErdEditorAttachElement.test.ts
@@ -1,4 +1,12 @@
-import { createRef, FC, html, observable, Ref, ref } from '@dineug/r-html';
+import {
+  AnyAction,
+  createRef,
+  FC,
+  html,
+  observable,
+  Ref,
+  ref,
+} from '@dineug/r-html';
 import {
   afterEach,
   beforeEach,
@@ -20,6 +28,23 @@ import {
   ErdEditorProps,
 } from '@/components/erd-editor/ErdEditor';
 import { useErdEditorAttachElement } from '@/components/erd-editor/useErdEditorAttachElement';
+import {
+  dragSelectRectAction,
+  editTableAction,
+  focusColumnAction,
+  focusTableAction,
+  focusTableEndAction,
+  getLWWAction,
+  selectAction,
+  selectAllAction,
+  SHARED_DRAG_SELECT_TRACKER_TIMEOUT,
+  SHARED_FOCUS_TRACKER_TIMEOUT,
+  sharedDragSelectTrackerAction,
+  sharedFocusTrackerAction,
+  sharedSelectionTrackerAction,
+  unselectAllAction,
+} from '@/engine/modules/editor/atom.actions';
+import { FocusType, SelectType } from '@/engine/modules/editor/state';
 import { AccentColor, Appearance, GrayColor } from '@/themes/radix-ui-theme';
 import {
   openDiffViewerAction,
@@ -453,6 +478,377 @@ describe('useErdEditorAttachElement', () => {
     expect(mouseTrackerEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('broadcasts no presence while no shared store is open', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const focus = collectSharedFocus(app);
+    const selection = collectSharedSelection(app);
+    const dragSelect = collectSharedDragSelect(app);
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName }),
+      selectAction({ [tableId]: SelectType.table }),
+      dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+    );
+    await flush();
+
+    expect(focus).toHaveLength(0);
+    expect(selection).toHaveLength(0);
+    expect(dragSelect).toHaveLength(0);
+  });
+
+  it('broadcasts an absolute focus snapshot once a shared store exists', async () => {
+    const { app, ctx } = await setup();
+    const { tableId, columnId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedFocus(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      focusColumnAction({
+        tableId,
+        columnId,
+        focusType: FocusType.columnName,
+        $mod: false,
+        shiftKey: false,
+      })
+    );
+    await flush();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].payload).toEqual({
+      focus: { tableId, columnId, focusType: FocusType.columnName },
+    });
+    sharedStore.destroy();
+  });
+
+  it('repeats neither the same focus nor the edit flag', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedFocus(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName })
+    );
+    await flush();
+    expect(dispatched).toHaveLength(1);
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName })
+    );
+    await flush();
+    expect(dispatched).toHaveLength(1);
+
+    app.store.dispatchSync(editTableAction());
+    await flush();
+
+    expect(app.store.state.editor.focusTable?.edit).toBe(true);
+    expect(dispatched).toHaveLength(1);
+    sharedStore.destroy();
+  });
+
+  it('broadcasts a null focus when the focus ends', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedFocus(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName })
+    );
+    await flush();
+    app.store.dispatchSync(focusTableEndAction());
+    await flush();
+
+    expect(dispatched).toHaveLength(2);
+    expect(dispatched[1].payload).toEqual({ focus: null });
+    sharedStore.destroy();
+  });
+
+  it('skips every presence channel when the shared store opts out', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const focus = collectSharedFocus(app);
+    const selection = collectSharedSelection(app);
+    const dragSelect = collectSharedDragSelect(app);
+    const sharedStore = ctx.getSharedStore({ focusTracker: false });
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName }),
+      selectAction({ [tableId]: SelectType.table }),
+      dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+    );
+    await flush();
+
+    expect(focus).toHaveLength(0);
+    expect(selection).toHaveLength(0);
+    expect(dragSelect).toHaveLength(0);
+    sharedStore.destroy();
+  });
+
+  it('ends focus tracking when the last shared store is an opted-out one', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedFocus(app);
+
+    const tracked = ctx.getSharedStore();
+    const untracked = ctx.getSharedStore({ focusTracker: false });
+
+    tracked.destroy();
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName })
+    );
+    await flush();
+    expect(dispatched).toHaveLength(1);
+
+    untracked.destroy();
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableComment })
+    );
+    await flush();
+
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it('rebroadcasts the unchanged focus so a joining peer learns it', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedFocus(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName })
+    );
+    await flush();
+    expect(dispatched).toHaveLength(1);
+
+    app.store.dispatchSync(getLWWAction());
+    await flush();
+
+    expect(dispatched).toHaveLength(2);
+    expect(dispatched[1].payload).toEqual({
+      focus: { tableId, columnId: null, focusType: FocusType.tableName },
+    });
+    sharedStore.destroy();
+  });
+
+  it('heartbeats the held focus so a peer never expires a live marker', async () => {
+    vi.useFakeTimers();
+    try {
+      const { app, ctx } = await setup();
+      const { tableId } = await seedUsersTable(app, ctx);
+      const dispatched = collectSharedFocus(app);
+      const sharedStore = ctx.getSharedStore();
+
+      app.store.dispatchSync(
+        focusTableAction({ tableId, focusType: FocusType.tableName })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(dispatched).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(SHARED_FOCUS_TRACKER_TIMEOUT);
+
+      expect(dispatched.length).toBeGreaterThan(1);
+      expect(dispatched.at(-1)!.payload).toEqual({
+        focus: { tableId, columnId: null, focusType: FocusType.tableName },
+      });
+
+      sharedStore.destroy();
+      const settled = dispatched.length;
+      await vi.advanceTimersByTimeAsync(SHARED_FOCUS_TRACKER_TIMEOUT);
+      expect(dispatched).toHaveLength(settled);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('broadcasts the sorted selection snapshot once a shared store exists', async () => {
+    const { app, ctx } = await setup();
+    const { first, second } = await seedTwoTables(app, ctx);
+    const dispatched = collectSharedSelection(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      selectAction({ [second]: SelectType.table, [first]: SelectType.table })
+    );
+    await flush();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].payload).toEqual({
+      selectedIds: [first, second].sort(),
+    });
+    sharedStore.destroy();
+  });
+
+  it('repeats no selection broadcast when the same set arrives in another order', async () => {
+    const { app, ctx } = await setup();
+    const { first, second } = await seedTwoTables(app, ctx);
+    const dispatched = collectSharedSelection(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      selectAction({ [second]: SelectType.table, [first]: SelectType.table })
+    );
+    await flush();
+    const selectOrder = Object.keys(app.store.state.editor.selectedMap);
+    expect(dispatched).toHaveLength(1);
+
+    app.store.dispatchSync(selectAllAction());
+    await flush();
+    const selectAllOrder = Object.keys(app.store.state.editor.selectedMap);
+
+    expect(selectAllOrder).not.toEqual(selectOrder);
+    expect([...selectAllOrder].sort()).toEqual([...selectOrder].sort());
+    expect(dispatched).toHaveLength(1);
+    sharedStore.destroy();
+  });
+
+  it('broadcasts an empty selection when everything is unselected', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const dispatched = collectSharedSelection(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(selectAction({ [tableId]: SelectType.table }));
+    await flush();
+    app.store.dispatchSync(unselectAllAction());
+    await flush();
+
+    expect(dispatched).toHaveLength(2);
+    expect(dispatched[1].payload).toEqual({ selectedIds: [] });
+    sharedStore.destroy();
+  });
+
+  it('broadcasts a detached copy of the local drag box', async () => {
+    const { app, ctx } = await setup();
+    const dispatched = collectSharedDragSelect(app);
+    const sharedStore = ctx.getSharedStore();
+    const rect = { x: 10, y: 20, w: 30, h: 40 };
+
+    app.store.dispatchSync(dragSelectRectAction({ rect }));
+    await flush();
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].payload).toEqual({ rect });
+    expect(dispatched[0].payload.rect).not.toBe(
+      app.store.state.editor.dragSelect
+    );
+    sharedStore.destroy();
+  });
+
+  it('broadcasts a null drag box when the drag ends', async () => {
+    const { app, ctx } = await setup();
+    const dispatched = collectSharedDragSelect(app);
+    const sharedStore = ctx.getSharedStore();
+
+    app.store.dispatchSync(
+      dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+    );
+    await flush();
+    app.store.dispatchSync(dragSelectRectAction({ rect: null }));
+    await flush();
+
+    expect(dispatched).toHaveLength(2);
+    expect(dispatched[1].payload).toEqual({ rect: null });
+    sharedStore.destroy();
+  });
+
+  it('rebroadcasts every presence channel so a joining peer learns them', async () => {
+    const { app, ctx } = await setup();
+    const { tableId } = await seedUsersTable(app, ctx);
+    const focus = collectSharedFocus(app);
+    const selection = collectSharedSelection(app);
+    const dragSelect = collectSharedDragSelect(app);
+    const sharedStore = ctx.getSharedStore();
+    const rect = { x: 5, y: 6, w: 7, h: 8 };
+
+    app.store.dispatchSync(
+      focusTableAction({ tableId, focusType: FocusType.tableName }),
+      selectAction({ [tableId]: SelectType.table }),
+      dragSelectRectAction({ rect })
+    );
+    await flush();
+    expect(focus).toHaveLength(1);
+    expect(selection).toHaveLength(1);
+    expect(dragSelect).toHaveLength(1);
+
+    app.store.dispatchSync(getLWWAction());
+    await flush();
+
+    expect(focus).toHaveLength(2);
+    expect(selection).toHaveLength(2);
+    expect(dragSelect).toHaveLength(2);
+    expect(focus[1].payload).toEqual({
+      focus: { tableId, columnId: null, focusType: FocusType.tableName },
+    });
+    expect(selection[1].payload).toEqual({ selectedIds: [tableId] });
+    expect(dragSelect[1].payload).toEqual({ rect });
+    sharedStore.destroy();
+  });
+
+  it('heartbeats the held drag box and stays silent once it is gone', async () => {
+    vi.useFakeTimers();
+    try {
+      const { app, ctx } = await setup();
+      const dispatched = collectSharedDragSelect(app);
+      const sharedStore = ctx.getSharedStore();
+      const rect = { x: 12, y: 34, w: 56, h: 78 };
+
+      app.store.dispatchSync(dragSelectRectAction({ rect }));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(dispatched).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(SHARED_DRAG_SELECT_TRACKER_TIMEOUT);
+
+      expect(dispatched.length).toBeGreaterThan(1);
+      expect(dispatched.at(-1)!.payload).toEqual({ rect });
+
+      app.store.dispatchSync(dragSelectRectAction({ rect: null }));
+      await vi.advanceTimersByTimeAsync(0);
+      const settled = dispatched.length;
+      expect(dispatched.at(-1)!.payload).toEqual({ rect: null });
+
+      await vi.advanceTimersByTimeAsync(SHARED_DRAG_SELECT_TRACKER_TIMEOUT);
+
+      expect(dispatched).toHaveLength(settled);
+      sharedStore.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops every presence channel and both intervals on the last destroy', async () => {
+    vi.useFakeTimers();
+    try {
+      const { app, ctx } = await setup();
+      const { tableId } = await seedUsersTable(app, ctx);
+      const focus = collectSharedFocus(app);
+      const selection = collectSharedSelection(app);
+      const dragSelect = collectSharedDragSelect(app);
+      const sharedStore = ctx.getSharedStore();
+
+      app.store.dispatchSync(
+        focusTableAction({ tableId, focusType: FocusType.tableName }),
+        selectAction({ [tableId]: SelectType.table }),
+        dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(focus).toHaveLength(1);
+      expect(selection).toHaveLength(1);
+      expect(dragSelect).toHaveLength(1);
+
+      sharedStore.destroy();
+      await vi.advanceTimersByTimeAsync(SHARED_DRAG_SELECT_TRACKER_TIMEOUT);
+      await vi.advanceTimersByTimeAsync(SHARED_FOCUS_TRACKER_TIMEOUT);
+
+      expect(focus).toHaveLength(1);
+      expect(selection).toHaveLength(1);
+      expect(dragSelect).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('tears every watcher and shared store down on destroy()', async () => {
     const { api, app, ctx } = await setup();
     ctx.getSharedStore({ mouseTracker: false });
@@ -568,4 +964,46 @@ describe('useErdEditorAttachElement', () => {
 
 function ctxSetLight(api: ReturnType<typeof useErdEditorAttachElement>) {
   api.themeState.options.appearance = Appearance.light;
+}
+
+async function seedUsersTable(app: AppContext, ctx: ErdEditorElement) {
+  ctx.setSchemaSQL('CREATE TABLE users (id INT);');
+  await flush();
+
+  const tableId = app.store.state.doc.tableIds[0];
+  const columnId =
+    app.store.state.collections.tableEntities[tableId].columnIds[0];
+  return { tableId, columnId };
+}
+
+async function seedTwoTables(app: AppContext, ctx: ErdEditorElement) {
+  ctx.setSchemaSQL(
+    'CREATE TABLE users (id INT);\nCREATE TABLE posts (id INT);'
+  );
+  await flush();
+
+  const [first, second] = app.store.state.doc.tableIds;
+  return { first, second };
+}
+
+function collectDispatched(app: AppContext, type: string) {
+  const dispatched: AnyAction[] = [];
+  app.store.subscribe(actions => {
+    actions.forEach(action => {
+      action.type === type && dispatched.push(action);
+    });
+  });
+  return dispatched;
+}
+
+function collectSharedFocus(app: AppContext) {
+  return collectDispatched(app, sharedFocusTrackerAction.type);
+}
+
+function collectSharedSelection(app: AppContext) {
+  return collectDispatched(app, sharedSelectionTrackerAction.type);
+}
+
+function collectSharedDragSelect(app: AppContext) {
+  return collectDispatched(app, sharedDragSelectTrackerAction.type);
 }

--- a/packages/erd-editor/src/components/erd-editor/useErdEditorAttachElement.ts
+++ b/packages/erd-editor/src/components/erd-editor/useErdEditorAttachElement.ts
@@ -8,7 +8,13 @@ import { AppContext, appDestroy } from '@/components/appContext';
 import { DatabaseVendorToDatabase } from '@/constants/sql/database';
 import {
   clearAction,
+  getLWWAction,
   initialClearAction,
+  SHARED_DRAG_SELECT_TRACKER_TIMEOUT,
+  SHARED_FOCUS_TRACKER_TIMEOUT,
+  sharedDragSelectTrackerAction,
+  sharedFocusTrackerAction,
+  sharedSelectionTrackerAction,
 } from '@/engine/modules/editor/atom.actions';
 import {
   initialLoadJsonAction$,
@@ -39,6 +45,7 @@ import {
   openDiffViewerAction,
   schemaGCAction,
 } from '@/utils/emitter';
+import { toSharedFocus, toSharedFocusKey } from '@/utils/focus';
 import { KeyBindingName, KeyBindingNameList } from '@/utils/keyboard-shortcut';
 import { createSchemaSQL } from '@/utils/schema-sql';
 import { hasDatabaseVendor, toSafeString } from '@/utils/validation';
@@ -100,6 +107,73 @@ export function useErdEditorAttachElement({ props, ctx, app, root }: Props) {
   const darkMode = useDarkMode();
   const { addUnsubscribe } = useUnmounted();
   const sharedStoreSet = new Set<SharedStore>();
+  let presenceTrackerUnsubscribe: Unsubscribe | null = null;
+  let presenceTrackerIntervalId: any = -1;
+  let dragSelectTrackerIntervalId: any = -1;
+  let sharedFocusKey = '';
+  let sharedSelectionKey = '';
+  let sharedDragSelectKey = '';
+
+  const broadcastSharedFocus = (force: boolean) => {
+    const focus = toSharedFocus(store.state.editor.focusTable);
+    const key = toSharedFocusKey(focus);
+    if (key === sharedFocusKey && !force) return;
+
+    sharedFocusKey = key;
+    store.dispatch(sharedFocusTrackerAction({ focus }));
+  };
+
+  const broadcastSharedSelection = (force: boolean) => {
+    const selectedIds = Object.keys(store.state.editor.selectedMap).sort();
+    const key = selectedIds.length ? JSON.stringify(selectedIds) : '';
+    if (key === sharedSelectionKey && !force) return;
+
+    sharedSelectionKey = key;
+    store.dispatch(sharedSelectionTrackerAction({ selectedIds }));
+  };
+
+  const broadcastSharedDragSelect = (force: boolean) => {
+    const rect = store.state.editor.dragSelect;
+    const key = rect ? JSON.stringify([rect.x, rect.y, rect.w, rect.h]) : '';
+    if (key === sharedDragSelectKey && !force) return;
+
+    sharedDragSelectKey = key;
+    store.dispatch(
+      sharedDragSelectTrackerAction({ rect: rect ? { ...rect } : null })
+    );
+  };
+
+  const presenceTrackerEnd = () => {
+    presenceTrackerUnsubscribe?.();
+    presenceTrackerUnsubscribe = null;
+    clearInterval(presenceTrackerIntervalId);
+    presenceTrackerIntervalId = -1;
+    clearInterval(dragSelectTrackerIntervalId);
+    dragSelectTrackerIntervalId = -1;
+  };
+
+  const presenceTrackerStart = () => {
+    presenceTrackerEnd();
+    sharedFocusKey = '';
+    sharedSelectionKey = '';
+    sharedDragSelectKey = '';
+    presenceTrackerUnsubscribe = store.subscribe(actions => {
+      const force = actions.some(action => action.type === getLWWAction.type);
+      broadcastSharedFocus(force);
+      broadcastSharedSelection(force);
+      broadcastSharedDragSelect(force);
+    });
+    presenceTrackerIntervalId = setInterval(() => {
+      sharedFocusKey && broadcastSharedFocus(true);
+      sharedSelectionKey && broadcastSharedSelection(true);
+    }, SHARED_FOCUS_TRACKER_TIMEOUT / 3);
+    dragSelectTrackerIntervalId = setInterval(() => {
+      sharedDragSelectKey && broadcastSharedDragSelect(true);
+    }, SHARED_DRAG_SELECT_TRACKER_TIMEOUT / 3);
+    broadcastSharedFocus(false);
+    broadcastSharedSelection(false);
+    broadcastSharedDragSelect(false);
+  };
 
   const emitChange = () => {
     getReadonly() || ctx.dispatchEvent(new CustomEvent('change'));
@@ -272,6 +346,7 @@ export function useErdEditorAttachElement({ props, ctx, app, root }: Props) {
 
   ctx.getSharedStore = config => {
     const mouseTracker = config?.mouseTracker ?? true;
+    const focusTracker = config?.focusTracker ?? true;
     const sharedStore = createSharedStore(store, config);
     const facade: SharedStore = Object.freeze({
       ...sharedStore,
@@ -281,6 +356,7 @@ export function useErdEditorAttachElement({ props, ctx, app, root }: Props) {
 
         if (sharedStoreSet.size === 0) {
           emitter.emit(mouseTrackerEndAction());
+          presenceTrackerEnd();
         }
       },
     });
@@ -288,6 +364,10 @@ export function useErdEditorAttachElement({ props, ctx, app, root }: Props) {
 
     if (mouseTracker) {
       emitter.emit(mouseTrackerStartAction());
+    }
+
+    if (focusTracker) {
+      presenceTrackerStart();
     }
 
     return facade;

--- a/packages/erd-editor/src/components/erd/canvas/Canvas.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/Canvas.tsx
@@ -7,6 +7,7 @@ import DrawRelationship from '@/components/erd/canvas/draw-relationship/DrawRela
 import DuplicateGhost from '@/components/erd/canvas/duplicate-ghost/DuplicateGhost';
 import HighLevelTable from '@/components/erd/canvas/high-level-table/HighLevelTable';
 import Memo from '@/components/erd/canvas/memo/Memo';
+import SharedDragSelect from '@/components/erd/canvas/shared-drag-select/SharedDragSelect';
 import SharedMouseTracker from '@/components/erd/canvas/shared-mouse-tracker/SharedMouseTracker';
 import Table from '@/components/erd/canvas/table/Table';
 import { Show } from '@/constants/schema';
@@ -99,6 +100,7 @@ const Canvas: FC<CanvasProps> = (props, ctx) => {
             <DrawRelationship root={props.root} draw={drawRelationship} />
           ) : null}
           <SharedMouseTracker />
+          <SharedDragSelect />
           <DuplicateGhost />
         </div>
       </div>

--- a/packages/erd-editor/src/components/erd/canvas/high-level-table/HighLevelTable.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/high-level-table/HighLevelTable.test.ts
@@ -17,14 +17,23 @@ import {
   TABLE_HEADER_HEIGHT,
   TABLE_PADDING,
 } from '@/constants/layout';
-import { selectAction } from '@/engine/modules/editor/atom.actions';
-import { SelectType } from '@/engine/modules/editor/state';
+import {
+  selectAction,
+  sharedFocusTrackerAction,
+  sharedSelectionTrackerAction,
+} from '@/engine/modules/editor/atom.actions';
+import {
+  FocusType,
+  SelectType,
+  SharedFocus,
+} from '@/engine/modules/editor/state';
 import { changeZoomLevelAction } from '@/engine/modules/settings/atom.actions';
 import {
   addTableAction,
   changeTableColorAction,
   changeTableNameAction,
 } from '@/engine/modules/table/atom.actions';
+import { Tag } from '@/engine/tag';
 import type { Table } from '@/internal-types';
 import {
   fontSize5,
@@ -34,6 +43,7 @@ import {
   fontSize9,
 } from '@/styles/typography.styles';
 import { calcTableWidths } from '@/utils/calcTable';
+import { toSharedColor } from '@/utils/sharedColor';
 
 let mounted: Mounted | null = null;
 
@@ -95,6 +105,13 @@ const mountTable = async (app: AppContext, table: Table) => {
   );
   return mounted;
 };
+
+const trackFocus = (app: AppContext, focus: SharedFocus | null) =>
+  app.store.dispatchSync({
+    ...sharedFocusTrackerAction({ focus }),
+    tags: Tag.shared,
+    meta: { editorId: 'remote-1' },
+  });
 
 describe('HighLevelTable', () => {
   it('positions the table box and stamps its id on the root', async () => {
@@ -271,5 +288,137 @@ describe('HighLevelTable', () => {
       other: SelectType.memo,
       [TABLE_ID]: SelectType.table,
     });
+  });
+
+  it('outlines the root while a remote editor focuses the table', async () => {
+    const app = createTestAppContext();
+    const table = seedTable(app);
+    await mountTable(app, table);
+
+    expect(rootOf().hasAttribute('data-shared-focus')).toBe(false);
+
+    trackFocus(app, {
+      tableId: TABLE_ID,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-focus')).toBe(true);
+
+    trackFocus(app, null);
+    await flush();
+
+    expect(app.store.state.editor.sharedFocusTrackerMap).toEqual({});
+    expect(rootOf().hasAttribute('data-shared-focus')).toBe(false);
+  });
+});
+
+describe('HighLevelTable shared select', () => {
+  const apps = new Set<AppContext>();
+
+  afterEach(() => {
+    for (const app of apps) {
+      for (const tracker of Object.values(
+        app.store.state.editor.sharedSelectionTrackerMap
+      )) {
+        clearTimeout(tracker.timeoutId);
+      }
+    }
+    apps.clear();
+  });
+
+  const trackSelection = (
+    app: AppContext,
+    selectedIds: string[],
+    editorId = 'remote-1'
+  ) => {
+    apps.add(app);
+    app.store.dispatchSync({
+      ...sharedSelectionTrackerAction({ selectedIds }),
+      tags: Tag.shared,
+      meta: { editorId },
+    });
+  };
+
+  const snapshotSelectedMap = (app: AppContext) => ({
+    ...app.store.state.editor.selectedMap,
+  });
+
+  it('leaves the root unmarked while no peer has selected it', async () => {
+    const app = createTestAppContext();
+    await mountTable(app, seedTable(app));
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the root in the peer color once a peer selects the table', async () => {
+    const app = createTestAppContext();
+    await mountTable(app, seedTable(app));
+
+    trackSelection(app, [TABLE_ID]);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('leaves the root unmarked while the peer selects another entity', async () => {
+    const app = createTestAppContext();
+    await mountTable(app, seedTable(app));
+
+    trackSelection(app, ['other-table']);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the root when the peer selection holds several ids', async () => {
+    const app = createTestAppContext();
+    await mountTable(app, seedTable(app));
+
+    trackSelection(app, ['memo-1', 'other-table', TABLE_ID]);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('clears the marker when the peer selection empties', async () => {
+    const app = createTestAppContext();
+    await mountTable(app, seedTable(app));
+
+    trackSelection(app, [TABLE_ID]);
+    await flush();
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+
+    trackSelection(app, []);
+    await flush();
+
+    expect(app.store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('never writes a peer selection into the local selection map', async () => {
+    const app = createTestAppContext();
+    app.store.dispatchSync(selectAction({ other: SelectType.memo }));
+    await mountTable(app, seedTable(app));
+
+    const before = snapshotSelectedMap(app);
+    expect(before).toEqual({ other: SelectType.memo });
+
+    trackSelection(app, [TABLE_ID, 'other-table']);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().hasAttribute('data-selected')).toBe(false);
+    expect(snapshotSelectedMap(app)).toEqual(before);
   });
 });

--- a/packages/erd-editor/src/components/erd/canvas/high-level-table/HighLevelTable.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/high-level-table/HighLevelTable.tsx
@@ -4,6 +4,8 @@ import { isEmpty } from 'es-toolkit/compat';
 import { useAppContext } from '@/components/appContext';
 import * as styles from '@/components/erd/canvas/table/Table.styles';
 import { useMoveTable } from '@/components/erd/canvas/table/useMoveTable';
+import { useSharedFocusTable } from '@/components/erd/canvas/table/useSharedFocusTable';
+import { useSharedSelectEntity } from '@/components/erd/canvas/useSharedSelectEntity';
 import { Table } from '@/internal-types';
 import {
   fontSize5,
@@ -23,6 +25,8 @@ export type HighLevelTableProps = {
 
 const HighLevelTable: FC<HighLevelTableProps> = (props, ctx) => {
   const app = useAppContext(ctx);
+  const { sharedFocusTableColor } = useSharedFocusTable(ctx, props.table.id);
+  const { sharedSelectColor } = useSharedSelectEntity(ctx, props.table.id);
   const { onMoveStart } = useMoveTable(ctx, props);
 
   const fontSize = () => {
@@ -67,6 +71,8 @@ const HighLevelTable: FC<HighLevelTableProps> = (props, ctx) => {
     const height = calcTableHeight(table);
 
     const isEmptyName = isEmpty(table.name.trim());
+    const sharedTableColor = sharedFocusTableColor();
+    const sharedSelected = sharedSelectColor();
 
     return (
       <div
@@ -77,8 +83,12 @@ const HighLevelTable: FC<HighLevelTableProps> = (props, ctx) => {
           'z-index': `${table.ui.zIndex}`,
           width: `${tableWidths.width}px`,
           height: `${height}px`,
+          '--shared-focus': sharedTableColor ?? '',
+          '--shared-select': sharedSelected ?? '',
         }}
         bool:data-selected={selected}
+        bool:data-shared-focus={Boolean(sharedTableColor)}
+        bool:data-shared-select={Boolean(sharedSelected)}
         data-id={table.id}
         on:mousedown={onMoveStart}
         on:touchstart={onMoveStart}

--- a/packages/erd-editor/src/components/erd/canvas/memo/Memo.styles.ts
+++ b/packages/erd-editor/src/components/erd/canvas/memo/Memo.styles.ts
@@ -23,6 +23,10 @@ export const root = css`
   &[data-selected] {
     border: 1px solid var(--memo-select);
   }
+
+  &[data-shared-select] {
+    box-shadow: 0 0 0 1px var(--shared-select);
+  }
 `;
 
 export const container = css`

--- a/packages/erd-editor/src/components/erd/canvas/memo/Memo.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/memo/Memo.test.ts
@@ -16,12 +16,17 @@ import {
   MEMO_HEADER_HEIGHT,
   MEMO_PADDING,
 } from '@/constants/layout';
-import { selectAction } from '@/engine/modules/editor/atom.actions';
+import {
+  selectAction,
+  sharedSelectionTrackerAction,
+} from '@/engine/modules/editor/atom.actions';
 import { SelectType } from '@/engine/modules/editor/state';
 import { addMemoAction } from '@/engine/modules/memo/atom.actions';
+import { Tag } from '@/engine/tag';
 import type { Memo as MemoType } from '@/internal-types';
 import { createMemo } from '@/utils/collection/memo.entity';
 import { InternalEventType } from '@/utils/internalEvents';
+import { toSharedColor } from '@/utils/sharedColor';
 
 let mounted: Mounted | null = null;
 
@@ -455,5 +460,120 @@ describe('Memo', () => {
     mounted = await mountAndFlush(html`<${Memo} memo=${createProps()} />`);
 
     expect(mounted.container.querySelectorAll('.sash')).toHaveLength(7);
+  });
+});
+
+describe('Memo shared select', () => {
+  const apps = new Set<AppContext>();
+
+  afterEach(() => {
+    for (const app of apps) {
+      for (const tracker of Object.values(
+        app.store.state.editor.sharedSelectionTrackerMap
+      )) {
+        clearTimeout(tracker.timeoutId);
+      }
+    }
+    apps.clear();
+  });
+
+  const trackSelection = (
+    app: AppContext,
+    selectedIds: string[],
+    editorId = 'remote-1'
+  ) => {
+    apps.add(app);
+    app.store.dispatchSync({
+      ...sharedSelectionTrackerAction({ selectedIds }),
+      tags: Tag.shared,
+      meta: { editorId },
+    });
+  };
+
+  const snapshotSelectedMap = (app: AppContext) => ({
+    ...app.store.state.editor.selectedMap,
+  });
+
+  const mountMemo = async (app: AppContext) => {
+    const entity = seedMemo(app);
+    mounted = await mountAndFlush(html`<${Memo} memo=${entity} />`, app);
+    return entity;
+  };
+
+  it('leaves the root unmarked while no peer has selected it', async () => {
+    const app = createTestAppContext();
+    await mountMemo(app);
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the root in the peer color once a peer selects the memo', async () => {
+    const app = createTestAppContext();
+    await mountMemo(app);
+
+    trackSelection(app, [MEMO_ID]);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('leaves the root unmarked while the peer selects another entity', async () => {
+    const app = createTestAppContext();
+    await mountMemo(app);
+
+    trackSelection(app, ['memo-2']);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the root when the peer selection holds several ids', async () => {
+    const app = createTestAppContext();
+    await mountMemo(app);
+
+    trackSelection(app, ['memo-2', 'table-1', MEMO_ID]);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('clears the marker when the peer selection empties', async () => {
+    const app = createTestAppContext();
+    await mountMemo(app);
+
+    trackSelection(app, [MEMO_ID]);
+    await flush();
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+
+    trackSelection(app, []);
+    await flush();
+
+    expect(app.store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(false);
+    expect(rootOf().style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('never writes a peer selection into the local selection map', async () => {
+    const app = createTestAppContext();
+    app.store.dispatchSync(selectAction({ other: SelectType.table }));
+    await mountMemo(app);
+
+    const before = snapshotSelectedMap(app);
+    expect(before).toEqual({ other: SelectType.table });
+
+    trackSelection(app, [MEMO_ID, 'memo-2']);
+    await flush();
+
+    expect(rootOf().hasAttribute('data-shared-select')).toBe(true);
+    expect(rootOf().hasAttribute('data-selected')).toBe(false);
+    expect(snapshotSelectedMap(app)).toEqual(before);
   });
 });

--- a/packages/erd-editor/src/components/erd/canvas/memo/Memo.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/memo/Memo.tsx
@@ -3,6 +3,7 @@ import { FC } from '@dineug/r-html';
 import { useAppContext } from '@/components/appContext';
 import { tryStartAltDragDuplicate } from '@/components/erd/canvas/altDragDuplicate';
 import MemoSash from '@/components/erd/canvas/memo/memo-sash/MemoSash';
+import { useSharedSelectEntity } from '@/components/erd/canvas/useSharedSelectEntity';
 import Icon from '@/components/primitives/icon/Icon';
 import { moveAllAction$ } from '@/engine/modules/editor/generator.actions';
 import { SelectType } from '@/engine/modules/editor/state';
@@ -27,6 +28,7 @@ export type MemoProps = {
 
 const Memo: FC<MemoProps> = (props, ctx) => {
   const app = useAppContext(ctx);
+  const { sharedSelectColor } = useSharedSelectEntity(ctx, props.memo.id);
 
   const handleMove = ({ event, movementX, movementY }: DragMove) => {
     event.type === 'mousemove' && event.preventDefault();
@@ -99,6 +101,7 @@ const Memo: FC<MemoProps> = (props, ctx) => {
     const { editor } = store.state;
     const { memo } = props;
     const selected = Boolean(editor.selectedMap[memo.id]);
+    const sharedSelected = sharedSelectColor();
     const width = calcMemoWidth(memo);
     const height = calcMemoHeight(memo);
 
@@ -111,8 +114,10 @@ const Memo: FC<MemoProps> = (props, ctx) => {
           'z-index': `${memo.ui.zIndex}`,
           width: `${width}px`,
           height: `${height}px`,
+          '--shared-select': sharedSelected ?? '',
         }}
         bool:data-selected={selected}
+        bool:data-shared-select={Boolean(sharedSelected)}
         bool:data-focus-border={selected}
         on:mousedown={handleMoveStart}
         on:touchstart={handleMoveStart}

--- a/packages/erd-editor/src/components/erd/canvas/shared-drag-select/SharedDragSelect.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/shared-drag-select/SharedDragSelect.test.ts
@@ -1,0 +1,192 @@
+import { html } from '@dineug/r-html';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import {
+  createTestAppContext,
+  flush,
+  mountAndFlush,
+  Mounted,
+} from '@/__test-utils__/index';
+import { AppContext } from '@/components/appContext';
+import SharedDragSelect from '@/components/erd/canvas/shared-drag-select/SharedDragSelect';
+import {
+  SHARED_DRAG_SELECT_TRACKER_TIMEOUT,
+  sharedDragSelectTrackerAction,
+} from '@/engine/modules/editor/atom.actions';
+import { Tag } from '@/engine/tag';
+import type { Rect } from '@/utils/dragSelect';
+import { SharedColors, toSharedColor } from '@/utils/sharedColor';
+
+let mounted: Mounted | null = null;
+const apps = new Set<AppContext>();
+
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+
+  for (const app of apps) {
+    for (const tracker of Object.values(
+      app.store.state.editor.sharedDragSelectTrackerMap
+    )) {
+      clearTimeout(tracker.timeoutId);
+    }
+  }
+  apps.clear();
+  vi.useRealTimers();
+});
+
+const createApp = () => {
+  const app = createTestAppContext();
+  apps.add(app);
+  return app;
+};
+
+const track = (app: AppContext, editorId: string, rect: Rect | null) =>
+  app.store.dispatchSync({
+    ...sharedDragSelectTrackerAction({ rect }),
+    tags: Tag.shared,
+    meta: { editorId },
+  });
+
+const boxes = () =>
+  Array.from(
+    mounted!.container.querySelectorAll<SVGSVGElement>(
+      '[data-testid="shared-drag-select"]'
+    )
+  );
+
+const toHex = (value: string) => {
+  if (!value.startsWith('rgb')) return value;
+
+  const channels = value.match(/\d+/g) ?? [];
+  return `#${channels
+    .slice(0, 3)
+    .map(channel => Number(channel).toString(16).padStart(2, '0'))
+    .join('')}`;
+};
+
+describe('SharedDragSelect', () => {
+  it('renders nothing while no remote editor is drag selecting', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    expect(boxes()).toHaveLength(0);
+  });
+
+  it('positions the box at the absolute rect the remote editor is dragging', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    track(app, 'remote-1', { x: 120, y: 240, w: 60, h: 30 });
+    await flush();
+
+    const [box] = boxes();
+    expect(box).toBeTruthy();
+    expect(box.style.left).toBe('120px');
+    expect(box.style.top).toBe('240px');
+    expect(box.style.width).toBe('60px');
+    expect(box.style.height).toBe('30px');
+  });
+
+  it('paints the box in the color that identifies its editor', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    track(app, 'remote-1', { x: 0, y: 0, w: 60, h: 30 });
+    await flush();
+
+    const [box] = boxes();
+    expect(box.style.stroke).toBeTruthy();
+    expect(SharedColors).toContain(toHex(box.style.stroke));
+    expect(toHex(box.style.stroke)).toBe(toSharedColor('remote-1'));
+    expect(toHex(box.style.fill)).toBe(toSharedColor('remote-1'));
+  });
+
+  it('keeps the dashed outline sized to the rect', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    track(app, 'remote-1', { x: 10, y: 20, w: 60, h: 30 });
+    await flush();
+
+    const rect = boxes()[0].querySelector('rect')!;
+    expect(rect).toBeTruthy();
+    expect(rect.getAttribute('stroke-dasharray')).toBe('3');
+    expect(rect.getAttribute('width')).toBe('60');
+    expect(rect.getAttribute('height')).toBe('30');
+  });
+
+  it('renders one box per remote editor dragging at the same time', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    track(app, 'remote-1', { x: 0, y: 0, w: 10, h: 10 });
+    await flush();
+    track(app, 'remote-2', { x: 100, y: 100, w: 20, h: 20 });
+    await flush();
+
+    const [first, second] = boxes();
+    expect(boxes()).toHaveLength(2);
+    expect(toHex(first.style.stroke)).toBe(toSharedColor('remote-1'));
+    expect(toHex(second.style.stroke)).toBe(toSharedColor('remote-2'));
+    expect(toHex(first.style.stroke)).not.toBe(toHex(second.style.stroke));
+  });
+
+  it('renders trackers that were already present before it mounted', async () => {
+    const app = createApp();
+    track(app, 'remote-1', { x: 0, y: 0, w: 10, h: 10 });
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    expect(boxes()).toHaveLength(1);
+  });
+
+  it('drops the box when the remote editor ends its drag', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    track(app, 'remote-1', { x: 0, y: 0, w: 10, h: 10 });
+    track(app, 'remote-2', { x: 100, y: 100, w: 20, h: 20 });
+    await flush();
+    expect(boxes()).toHaveLength(2);
+
+    track(app, 'remote-1', null);
+    await flush();
+
+    const [box] = boxes();
+    expect(boxes()).toHaveLength(1);
+    expect(toHex(box.style.stroke)).toBe(toSharedColor('remote-2'));
+  });
+
+  it('drops the box when the drag expires without any closing signal', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+
+    vi.useFakeTimers();
+    track(app, 'remote-1', { x: 0, y: 0, w: 10, h: 10 });
+    await flush();
+    expect(boxes()).toHaveLength(1);
+
+    vi.advanceTimersByTime(SHARED_DRAG_SELECT_TRACKER_TIMEOUT + 1);
+    await flush();
+
+    expect(boxes()).toHaveLength(0);
+  });
+
+  it('stops reacting to the tracker map once unmounted', async () => {
+    const app = createApp();
+    mounted = await mountAndFlush(html`<${SharedDragSelect} />`, app);
+    const container = mounted.container;
+
+    mounted.unmount();
+    mounted = null;
+
+    expect(() =>
+      track(app, 'remote-1', { x: 0, y: 0, w: 10, h: 10 })
+    ).not.toThrow();
+    await flush();
+
+    expect(
+      container.querySelectorAll('[data-testid="shared-drag-select"]')
+    ).toHaveLength(0);
+  });
+});

--- a/packages/erd-editor/src/components/erd/canvas/shared-drag-select/SharedDragSelect.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/shared-drag-select/SharedDragSelect.tsx
@@ -1,0 +1,75 @@
+import { FC, observable, onMounted, repeat, watch } from '@dineug/r-html';
+
+import { useAppContext } from '@/components/appContext';
+import * as styles from '@/components/erd/drag-select/DragSelect.styles';
+import { useUnmounted } from '@/hooks/useUnmounted';
+import { toSharedColor } from '@/utils/sharedColor';
+
+export type SharedDragSelectProps = {};
+
+const SharedDragSelect: FC<SharedDragSelectProps> = (props, ctx) => {
+  const app = useAppContext(ctx);
+  const { addUnsubscribe } = useUnmounted();
+  const state = observable({ force: false });
+
+  const forceUpdate = () => {
+    state.force = !state.force;
+  };
+
+  onMounted(() => {
+    const { store } = app.value;
+    const {
+      editor: { sharedDragSelectTrackerMap },
+    } = store.state;
+
+    addUnsubscribe(watch(sharedDragSelectTrackerMap).subscribe(forceUpdate));
+  });
+
+  return () => {
+    const { store } = app.value;
+    const {
+      editor: { sharedDragSelectTrackerMap },
+    } = store.state;
+
+    // observable dependency
+    state.force;
+
+    return (
+      <>
+        {repeat(
+          Object.values(sharedDragSelectTrackerMap),
+          tracker => tracker.id,
+          tracker => {
+            const color = toSharedColor(tracker.id);
+
+            return (
+              <svg
+                class={styles.dragSelect}
+                data-testid="shared-drag-select"
+                style={{
+                  left: `${tracker.x}px`,
+                  top: `${tracker.y}px`,
+                  width: `${tracker.w}px`,
+                  height: `${tracker.h}px`,
+                  stroke: color,
+                  fill: color,
+                }}
+              >
+                <rect
+                  width={tracker.w}
+                  height={tracker.h}
+                  stroke-width="1"
+                  stroke-opacity="1"
+                  stroke-dasharray="3"
+                  fill-opacity="0.08"
+                ></rect>
+              </svg>
+            );
+          }
+        )}
+      </>
+    );
+  };
+};
+
+export default SharedDragSelect;

--- a/packages/erd-editor/src/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor.test.ts
@@ -5,6 +5,7 @@ import { flush, mountAndFlush, Mounted } from '@/__test-utils__/index';
 import SharedMouseCursor from '@/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor';
 import * as styles from '@/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor.styles';
 import type { SharedMouseTracker } from '@/engine/modules/editor/state';
+import { SharedColors, toSharedColor } from '@/utils/sharedColor';
 
 let mounted: Mounted | null = null;
 
@@ -26,6 +27,16 @@ const createTracker = (
 
 const cursorOf = () =>
   mounted!.container.querySelector<HTMLElement>(`.${String(styles.cursor)}`)!;
+
+const toHex = (value: string) => {
+  if (!value.startsWith('rgb')) return value;
+
+  const channels = value.match(/\d+/g) ?? [];
+  return `#${channels
+    .slice(0, 3)
+    .map(channel => Number(channel).toString(16).padStart(2, '0'))
+    .join('')}`;
+};
 
 const nextFrame = () =>
   new Promise<void>(resolve => {
@@ -106,6 +117,20 @@ describe('SharedMouseCursor', () => {
     await waitFrames(2);
 
     expect(cursorOf().querySelector('span')?.textContent).toBe('renamed');
+  });
+
+  it('paints itself in the color that identifies its editor', async () => {
+    mounted = await mountAndFlush(
+      html`<${SharedMouseCursor}
+        tracker=${createTracker({ id: 'remote-1' })}
+      />`
+    );
+
+    const el = cursorOf();
+    expect(el.style.color).toBeTruthy();
+    expect(SharedColors).toContain(toHex(el.style.color));
+    expect(toHex(el.style.color)).toBe(toSharedColor('remote-1'));
+    expect(toHex(el.style.fill)).toBe(toHex(el.style.color));
   });
 
   it('stops following the tracker once unmounted', async () => {

--- a/packages/erd-editor/src/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/shared-mouse-tracker/shared-mouse-cursor/SharedMouseCursor.tsx
@@ -4,6 +4,7 @@ import Icon from '@/components/primitives/icon/Icon';
 import { SharedMouseTracker } from '@/engine/modules/editor/state';
 import { useUnmounted } from '@/hooks/useUnmounted';
 import { animationFrames$ } from '@/utils/globalEventObservable';
+import { toSharedColor } from '@/utils/sharedColor';
 
 import * as styles from './SharedMouseCursor.styles';
 
@@ -30,13 +31,19 @@ const SharedMouseCursor: FC<SharedMouseCursorProps> = (props, ctx) => {
 
   return () => {
     const {
-      tracker: { nickname },
+      tracker: { id, nickname },
     } = props;
+    const color = toSharedColor(id);
 
     return (
       <div
         class={styles.cursor}
-        style={{ left: `${state.x}px`, top: `${state.y}px` }}
+        style={{
+          left: `${state.x}px`,
+          top: `${state.y}px`,
+          color,
+          fill: color,
+        }}
       >
         <Icon name="arrow-pointer" size={16} />
         <span>{nickname}</span>

--- a/packages/erd-editor/src/components/erd/canvas/table/Table.styles.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/Table.styles.test.ts
@@ -15,6 +15,12 @@ import { typography } from '@/styles/typography.styles';
 const sourceOf = (style: { strings: TemplateStringsArray }) =>
   style.strings.join('');
 
+const blockOf = (source: string, selector: string) => {
+  const start = source.indexOf(`${selector} {`);
+
+  return source.slice(start, source.indexOf('}', start));
+};
+
 describe('Table.styles', () => {
   it('exports every class the Table template composes', () => {
     expect(Object.keys(styles).sort()).toEqual([
@@ -49,6 +55,28 @@ describe('Table.styles', () => {
     expect(source).toContain('color: var(--foreground)');
     expect(source).toContain('&[data-selected]');
     expect(source).toContain('border: 1px solid var(--table-select)');
+  });
+
+  it('marks a remote peer focus with an outline and underlines the focused header input', () => {
+    const source = sourceOf(styles.root);
+
+    expect(source).toContain('&[data-shared-focus]');
+    expect(source).toContain('outline: 1px solid var(--shared-focus)');
+    expect(source).toContain('outline-offset: 0');
+    expect(source).toContain('& .input-padding[data-shared-focus]');
+    expect(source).toContain(
+      'box-shadow: inset 0 -1.5px 0 var(--shared-focus)'
+    );
+  });
+
+  it('leaves the two border writes to the base and selected rules', () => {
+    const source = sourceOf(styles.root);
+
+    expect(source.match(/border:/g)).toHaveLength(2);
+    expect(blockOf(source, '&[data-shared-focus]')).not.toContain('border');
+    expect(
+      blockOf(source, '& .input-padding[data-shared-focus]')
+    ).not.toContain('border');
   });
 
   it('declares the column-row-move transition the flip animation toggles', () => {

--- a/packages/erd-editor/src/components/erd/canvas/table/Table.styles.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/Table.styles.ts
@@ -30,6 +30,19 @@ export const root = css`
     border: 1px solid var(--table-select);
   }
 
+  &[data-shared-focus] {
+    outline: 1px solid var(--shared-focus);
+    outline-offset: 0;
+  }
+
+  &[data-shared-select]:not([data-shared-focus]) {
+    box-shadow: 0 0 0 1px var(--shared-select);
+  }
+
+  & .input-padding[data-shared-focus] {
+    box-shadow: inset 0 -1.5px 0 var(--shared-focus);
+  }
+
   .column-row-move {
     transition: transform 0.3s;
   }

--- a/packages/erd-editor/src/components/erd/canvas/table/Table.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/Table.test.ts
@@ -16,10 +16,16 @@ import {
   focusColumnAction,
   focusTableAction,
   focusTableEndAction,
+  sharedFocusTrackerAction,
+  sharedSelectionTrackerAction,
   unselectAllAction,
 } from '@/engine/modules/editor/atom.actions';
 import { dragstartColumnAction$ } from '@/engine/modules/editor/generator.actions';
-import { FocusType } from '@/engine/modules/editor/state';
+import {
+  FocusType,
+  SelectType,
+  SharedFocus,
+} from '@/engine/modules/editor/state';
 import {
   changeMaxWidthCommentAction,
   changeShowAction,
@@ -30,8 +36,10 @@ import {
 } from '@/engine/modules/table/atom.actions';
 import { addTableAction$ } from '@/engine/modules/table/generator.actions';
 import { addColumnAction$ } from '@/engine/modules/table-column/generator.actions';
+import { Tag } from '@/engine/tag';
 import { Table as TableEntity } from '@/internal-types';
 import { simpleShortcutToString } from '@/utils/keyboard-shortcut';
+import { toSharedColor } from '@/utils/sharedColor';
 
 let mounted: Mounted | null = null;
 
@@ -698,5 +706,381 @@ describe('Table', () => {
     await flush();
 
     expect(table.columnIds).toEqual(columnIds);
+  });
+});
+
+describe('Table shared focus', () => {
+  const apps = new Set<AppContext>();
+
+  afterEach(() => {
+    for (const app of apps) {
+      for (const tracker of Object.values(
+        app.store.state.editor.sharedFocusTrackerMap
+      )) {
+        clearTimeout(tracker.timeoutId);
+      }
+    }
+    apps.clear();
+  });
+
+  const track = (
+    app: AppContext,
+    focus: SharedFocus | null,
+    editorId = 'remote-1'
+  ) => {
+    apps.add(app);
+    app.store.dispatchSync({
+      ...sharedFocusTrackerAction({ focus }),
+      tags: Tag.shared,
+      meta: { editorId },
+    });
+  };
+
+  const sharedFocusOf = (container: HTMLElement, selector: string) =>
+    container
+      .querySelector<HTMLElement>(selector)!
+      .hasAttribute('data-shared-focus');
+
+  const snapshotFocusTable = (app: AppContext) => {
+    const { focusTable } = app.store.state.editor;
+    return focusTable
+      ? { ...focusTable, selectColumnIds: [...focusTable.selectColumnIds] }
+      : null;
+  };
+
+  it('leaves the shell unmarked while no remote editor is focused', async () => {
+    const { root, container } = await setup({ columns: 1 });
+
+    expect(root.hasAttribute('data-shared-focus')).toBe(false);
+    expect(sharedFocusOf(container, '[data-type="tableName"]')).toBe(false);
+    expect(container.querySelectorAll('[data-shared-focus]')).toHaveLength(0);
+  });
+
+  it('marks the shell and the focused header cell for a remote editor', async () => {
+    const { app, table, root, container } = await setup();
+
+    track(app, {
+      tableId: table.id,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+
+    expect(root.hasAttribute('data-shared-focus')).toBe(true);
+    expect(sharedFocusOf(container, '[data-type="tableName"]')).toBe(true);
+    expect(sharedFocusOf(container, '[data-type="tableComment"]')).toBe(false);
+  });
+
+  it('ignores a remote focus that names another table', async () => {
+    const { app, root, container } = await setup();
+
+    track(app, {
+      tableId: 'other-table',
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+
+    expect(root.hasAttribute('data-shared-focus')).toBe(false);
+    expect(container.querySelectorAll('[data-shared-focus]')).toHaveLength(0);
+  });
+
+  it('marks only the column cell a remote editor is focused on', async () => {
+    const { app, table, root, container } = await setup({ columns: 2 });
+    const [firstId] = table.columnIds;
+
+    track(app, {
+      tableId: table.id,
+      columnId: firstId,
+      focusType: FocusType.columnName,
+    });
+    await flush();
+
+    expect(root.hasAttribute('data-shared-focus')).toBe(true);
+    expect(sharedFocusOf(container, '[data-type="tableName"]')).toBe(false);
+
+    const marked = Array.from(
+      container.querySelectorAll<HTMLElement>('.column-col[data-shared-focus]')
+    );
+    expect(marked).toHaveLength(1);
+    expect(marked[0].dataset.type).toBe('columnName');
+    expect(marked[0].closest<HTMLElement>('.column-row')!.dataset.id).toBe(
+      firstId
+    );
+  });
+
+  it('never moves the local focus', async () => {
+    const { app, table, container } = await setup({ columns: 1 });
+    const { store } = app;
+
+    store.dispatchSync(
+      focusColumnAction({
+        tableId: table.id,
+        columnId: table.columnIds[0],
+        focusType: FocusType.columnName,
+        $mod: false,
+        shiftKey: false,
+      })
+    );
+    await flush();
+
+    const before = snapshotFocusTable(app);
+    expect(before).toMatchObject({
+      tableId: table.id,
+      columnId: table.columnIds[0],
+      focusType: FocusType.columnName,
+    });
+
+    track(app, {
+      tableId: table.id,
+      columnId: null,
+      focusType: FocusType.tableComment,
+    });
+    await flush();
+
+    expect(store.state.editor.sharedFocusTrackerMap['remote-1']).toMatchObject({
+      id: 'remote-1',
+      tableId: table.id,
+      columnId: null,
+      focusType: FocusType.tableComment,
+    });
+    expect(sharedFocusOf(container, '[data-type="tableComment"]')).toBe(true);
+    expect(snapshotFocusTable(app)).toEqual(before);
+  });
+
+  it('clears the marker when the remote editor drops its focus', async () => {
+    const { app, table, root, container } = await setup();
+
+    track(app, {
+      tableId: table.id,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+    expect(root.hasAttribute('data-shared-focus')).toBe(true);
+
+    track(app, null);
+    await flush();
+
+    expect(app.store.state.editor.sharedFocusTrackerMap).toEqual({});
+    expect(root.hasAttribute('data-shared-focus')).toBe(false);
+    expect(container.querySelectorAll('[data-shared-focus]')).toHaveLength(0);
+  });
+
+  it('paints the marker in the color that identifies the peer', async () => {
+    const { app, table, root, container } = await setup({ columns: 1 });
+    const [firstId] = table.columnIds;
+
+    track(app, {
+      tableId: table.id,
+      columnId: firstId,
+      focusType: FocusType.columnName,
+    });
+    await flush();
+
+    const cell = container.querySelector<HTMLElement>(
+      '.column-col[data-type="columnName"][data-shared-focus]'
+    )!;
+
+    expect(root.style.getPropertyValue('--shared-focus')).toBe(
+      toSharedColor('remote-1')
+    );
+    expect(cell.style.getPropertyValue('--shared-focus')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('gives two peers their own colors', async () => {
+    const { app, table, root } = await setup();
+    const focus = {
+      tableId: table.id,
+      columnId: null,
+      focusType: FocusType.tableName,
+    };
+
+    track(app, focus, 'remote-1');
+    await flush();
+    const first = root.style.getPropertyValue('--shared-focus');
+
+    track(app, null, 'remote-1');
+    track(app, focus, 'remote-2');
+    await flush();
+    const second = root.style.getPropertyValue('--shared-focus');
+
+    expect(first).toBe(toSharedColor('remote-1'));
+    expect(second).toBe(toSharedColor('remote-2'));
+    expect(second).not.toBe(first);
+  });
+});
+
+describe('Table shared select', () => {
+  const apps = new Set<AppContext>();
+
+  afterEach(() => {
+    for (const app of apps) {
+      const { editor } = app.store.state;
+      for (const tracker of Object.values(editor.sharedSelectionTrackerMap)) {
+        clearTimeout(tracker.timeoutId);
+      }
+      for (const tracker of Object.values(editor.sharedFocusTrackerMap)) {
+        clearTimeout(tracker.timeoutId);
+      }
+    }
+    apps.clear();
+  });
+
+  const trackSelection = (
+    app: AppContext,
+    selectedIds: string[],
+    editorId = 'remote-1'
+  ) => {
+    apps.add(app);
+    app.store.dispatchSync({
+      ...sharedSelectionTrackerAction({ selectedIds }),
+      tags: Tag.shared,
+      meta: { editorId },
+    });
+  };
+
+  const trackFocus = (
+    app: AppContext,
+    focus: SharedFocus | null,
+    editorId = 'remote-1'
+  ) => {
+    apps.add(app);
+    app.store.dispatchSync({
+      ...sharedFocusTrackerAction({ focus }),
+      tags: Tag.shared,
+      meta: { editorId },
+    });
+  };
+
+  const snapshotSelectedMap = (app: AppContext) => ({
+    ...app.store.state.editor.selectedMap,
+  });
+
+  it('leaves the shell unmarked while no peer has selected it', async () => {
+    const { root } = await setup();
+
+    expect(root.hasAttribute('data-shared-select')).toBe(false);
+    expect(root.style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the shell in the peer color once a peer selects the table', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, [table.id]);
+    await flush();
+
+    expect(
+      app.store.state.editor.sharedSelectionTrackerMap['remote-1']
+    ).toMatchObject({ id: 'remote-1', selectedIds: [table.id] });
+    expect(root.hasAttribute('data-shared-select')).toBe(true);
+    expect(root.style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('leaves the shell unmarked while the peer selects another entity', async () => {
+    const { app, root } = await setup();
+
+    trackSelection(app, ['other-table']);
+    await flush();
+
+    expect(root.hasAttribute('data-shared-select')).toBe(false);
+    expect(root.style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('marks the shell when the peer selection holds several ids', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, ['memo-1', 'other-table', table.id]);
+    await flush();
+
+    expect(root.hasAttribute('data-shared-select')).toBe(true);
+    expect(root.style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+  });
+
+  it('follows a peer that widens its selection onto this table', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, ['other-table']);
+    await flush();
+    expect(root.hasAttribute('data-shared-select')).toBe(false);
+
+    trackSelection(app, ['other-table', table.id]);
+    await flush();
+
+    expect(root.hasAttribute('data-shared-select')).toBe(true);
+  });
+
+  it('clears the marker when the peer selection empties', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, [table.id]);
+    await flush();
+    expect(root.hasAttribute('data-shared-select')).toBe(true);
+
+    trackSelection(app, []);
+    await flush();
+
+    expect(app.store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(root.hasAttribute('data-shared-select')).toBe(false);
+    expect(root.style.getPropertyValue('--shared-select')).toBe('');
+  });
+
+  it('gives two peers their own colors', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, [table.id], 'remote-1');
+    await flush();
+    const first = root.style.getPropertyValue('--shared-select');
+
+    trackSelection(app, [], 'remote-1');
+    trackSelection(app, [table.id], 'remote-2');
+    await flush();
+    const second = root.style.getPropertyValue('--shared-select');
+
+    expect(first).toBe(toSharedColor('remote-1'));
+    expect(second).toBe(toSharedColor('remote-2'));
+    expect(second).not.toBe(first);
+  });
+
+  it('never writes a peer selection into the local selection map', async () => {
+    const { app, table } = await setup();
+
+    const before = snapshotSelectedMap(app);
+    expect(before).toEqual({ [table.id]: SelectType.table });
+
+    trackSelection(app, [table.id, 'ghost-table']);
+    await flush();
+
+    expect(snapshotSelectedMap(app)).toEqual(before);
+  });
+
+  it('carries a local selection, a peer selection and a peer focus at once', async () => {
+    const { app, table, root } = await setup();
+
+    trackSelection(app, [table.id], 'remote-1');
+    trackFocus(
+      app,
+      { tableId: table.id, columnId: null, focusType: FocusType.tableName },
+      'remote-2'
+    );
+    await flush();
+
+    expect(root.hasAttribute('data-selected')).toBe(true);
+    expect(root.hasAttribute('data-shared-select')).toBe(true);
+    expect(root.hasAttribute('data-shared-focus')).toBe(true);
+    expect(root.style.getPropertyValue('--shared-select')).toBe(
+      toSharedColor('remote-1')
+    );
+    expect(root.style.getPropertyValue('--shared-focus')).toBe(
+      toSharedColor('remote-2')
+    );
+    expect(toSharedColor('remote-2')).not.toBe(toSharedColor('remote-1'));
+    expect(snapshotSelectedMap(app)).toEqual({ [table.id]: SelectType.table });
   });
 });

--- a/packages/erd-editor/src/components/erd/canvas/table/Table.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/table/Table.tsx
@@ -12,6 +12,7 @@ import { Subscription } from 'rxjs';
 
 import { useAppContext } from '@/components/appContext';
 import Column from '@/components/erd/canvas/table/column/Column';
+import { useSharedSelectEntity } from '@/components/erd/canvas/useSharedSelectEntity';
 import EditInput from '@/components/primitives/edit-input/EditInput';
 import Icon from '@/components/primitives/icon/Icon';
 import { Show } from '@/constants/schema';
@@ -46,6 +47,7 @@ import { takeUnsubscribe } from '@/utils/rx-operators/takeUnsubscribe';
 import * as styles from './Table.styles';
 import { useFocusTable } from './useFocusTable';
 import { useMoveTable } from './useMoveTable';
+import { useSharedFocusTable } from './useSharedFocusTable';
 
 export type TableProps = {
   table: Table;
@@ -58,6 +60,11 @@ const Table: FC<TableProps> = (props, ctx) => {
     ctx,
     props.table.id
   );
+  const { sharedFocusColor, sharedFocusTableColor } = useSharedFocusTable(
+    ctx,
+    props.table.id
+  );
+  const { sharedSelectColor } = useSharedSelectEntity(ctx, props.table.id);
   const { onMoveStart } = useMoveTable(ctx, props);
   const { addUnsubscribe } = useUnmounted();
 
@@ -230,6 +237,11 @@ const Table: FC<TableProps> = (props, ctx) => {
       state.dragstartId !== null &&
       !table.columnIds.includes(state.dragstartId);
 
+    const sharedTableColor = sharedFocusTableColor();
+    const sharedSelected = sharedSelectColor();
+    const sharedNameColor = sharedFocusColor(FocusType.tableName);
+    const sharedCommentColor = sharedFocusColor(FocusType.tableComment);
+
     const columns = query(collections)
       .collection('tableColumnEntities')
       .selectByIds(
@@ -247,10 +259,14 @@ const Table: FC<TableProps> = (props, ctx) => {
           'z-index': `${table.ui.zIndex}`,
           width: `${tableWidths.width}px`,
           height: `${height}px`,
+          '--shared-focus': sharedTableColor ?? '',
+          '--shared-select': sharedSelected ?? '',
         }}
         use:ref={ref(root)}
         bool:data-selected={selected}
         bool:data-focus-border={selected}
+        bool:data-shared-focus={Boolean(sharedTableColor)}
+        bool:data-shared-select={Boolean(sharedSelected)}
         data-id={table.id}
         on:mousedown={onMoveStart}
         on:touchstart={onMoveStart}
@@ -287,6 +303,8 @@ const Table: FC<TableProps> = (props, ctx) => {
             <div
               class="input-padding"
               data-type="tableName"
+              bool:data-shared-focus={Boolean(sharedNameColor)}
+              style={{ '--shared-focus': sharedNameColor ?? '' }}
               on:mousedown={() => {
                 handleFocus(FocusType.tableName);
               }}
@@ -309,6 +327,8 @@ const Table: FC<TableProps> = (props, ctx) => {
               <div
                 class="input-padding"
                 data-type="tableComment"
+                bool:data-shared-focus={Boolean(sharedCommentColor)}
+                style={{ '--shared-focus': sharedCommentColor ?? '' }}
                 on:mousedown={() => {
                   handleFocus(FocusType.tableComment);
                 }}
@@ -367,6 +387,34 @@ const Table: FC<TableProps> = (props, ctx) => {
                 editDataType={hasEdit(FocusType.columnDataType, column.id)}
                 editDefault={hasEdit(FocusType.columnDefault, column.id)}
                 editComment={hasEdit(FocusType.columnComment, column.id)}
+                sharedFocusName={sharedFocusColor(
+                  FocusType.columnName,
+                  column.id
+                )}
+                sharedFocusDataType={sharedFocusColor(
+                  FocusType.columnDataType,
+                  column.id
+                )}
+                sharedFocusNotNull={sharedFocusColor(
+                  FocusType.columnNotNull,
+                  column.id
+                )}
+                sharedFocusDefault={sharedFocusColor(
+                  FocusType.columnDefault,
+                  column.id
+                )}
+                sharedFocusComment={sharedFocusColor(
+                  FocusType.columnComment,
+                  column.id
+                )}
+                sharedFocusUnique={sharedFocusColor(
+                  FocusType.columnUnique,
+                  column.id
+                )}
+                sharedFocusAutoIncrement={sharedFocusColor(
+                  FocusType.columnAutoIncrement,
+                  column.id
+                )}
                 draggable={true}
                 ghost={isGhostColumn && column.id === state.dragstartId}
                 onDragstart={handleDragstartColumn}

--- a/packages/erd-editor/src/components/erd/canvas/table/column/Column.styles.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/column/Column.styles.test.ts
@@ -53,12 +53,20 @@ describe('Column.styles', () => {
     expect(text).toContain('& > .column-col');
   });
 
+  it('underlines the single column cell a remote peer has focused', () => {
+    const text = staticText(styles.root);
+
+    expect(text).toContain('& > .column-col[data-shared-focus]');
+    expect(text).toContain('box-shadow: inset 0 -1.5px 0 var(--shared-focus)');
+  });
+
   it('drives the row colors from the theme custom properties', () => {
     const text = staticText(styles.root);
 
     expect(text).toContain('var(--foreground)');
     expect(text).toContain('var(--column-hover)');
     expect(text).toContain('var(--column-select)');
+    expect(text).toContain('var(--shared-focus)');
   });
 
   it('hides the dragging row and removes the ghost row from view', () => {

--- a/packages/erd-editor/src/components/erd/canvas/table/column/Column.styles.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/column/Column.styles.ts
@@ -34,6 +34,10 @@ export const root = css`
     padding: ${COLUMN_PADDING}px ${INPUT_MARGIN_RIGHT}px ${COLUMN_PADDING}px 0;
   }
 
+  & > .column-col[data-shared-focus] {
+    box-shadow: inset 0 -1.5px 0 var(--shared-focus);
+  }
+
   &.none-hover {
     background-color: transparent;
   }

--- a/packages/erd-editor/src/components/erd/canvas/table/column/Column.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/column/Column.test.ts
@@ -36,6 +36,7 @@ import {
 import type { Column as ColumnEntity } from '@/internal-types';
 import { bHas } from '@/utils/bit';
 import { simpleShortcutToString } from '@/utils/keyboard-shortcut';
+import { toSharedColor } from '@/utils/sharedColor';
 
 type TemplateOptions = {
   selected?: boolean;
@@ -46,6 +47,13 @@ type TemplateOptions = {
   focusComment?: boolean;
   focusUnique?: boolean;
   focusAutoIncrement?: boolean;
+  sharedFocusName?: string | null;
+  sharedFocusDataType?: string | null;
+  sharedFocusNotNull?: string | null;
+  sharedFocusDefault?: string | null;
+  sharedFocusComment?: string | null;
+  sharedFocusUnique?: string | null;
+  sharedFocusAutoIncrement?: string | null;
   editName?: boolean;
   editDataType?: boolean;
   editDefault?: boolean;
@@ -69,6 +77,13 @@ function columnTemplate(column: ColumnEntity, options: TemplateOptions = {}) {
     focusComment = false,
     focusUnique = false,
     focusAutoIncrement = false,
+    sharedFocusName = null,
+    sharedFocusDataType = null,
+    sharedFocusNotNull = null,
+    sharedFocusDefault = null,
+    sharedFocusComment = null,
+    sharedFocusUnique = null,
+    sharedFocusAutoIncrement = null,
     editName = false,
     editDataType = false,
     editDefault = false,
@@ -94,6 +109,13 @@ function columnTemplate(column: ColumnEntity, options: TemplateOptions = {}) {
       focusComment=${focusComment}
       focusUnique=${focusUnique}
       focusAutoIncrement=${focusAutoIncrement}
+      sharedFocusName=${sharedFocusName}
+      sharedFocusDataType=${sharedFocusDataType}
+      sharedFocusNotNull=${sharedFocusNotNull}
+      sharedFocusDefault=${sharedFocusDefault}
+      sharedFocusComment=${sharedFocusComment}
+      sharedFocusUnique=${sharedFocusUnique}
+      sharedFocusAutoIncrement=${sharedFocusAutoIncrement}
       editName=${editName}
       editDataType=${editDataType}
       editDefault=${editDefault}
@@ -419,6 +441,89 @@ describe('Column', () => {
         COLUMN_ID,
         'c2',
       ]);
+    });
+  });
+
+  describe('shared focus', () => {
+    const PEER_COLOR = toSharedColor('peer-1');
+
+    const sharedFocusMapOf = (m: Mounted) =>
+      Object.fromEntries(
+        Array.from(m.container.querySelectorAll('.column-col[data-type]')).map(
+          el => [
+            el.getAttribute('data-type'),
+            el.hasAttribute('data-shared-focus'),
+          ]
+        )
+      );
+
+    const noSharedFocus = {
+      columnName: false,
+      columnDataType: false,
+      columnNotNull: false,
+      columnUnique: false,
+      columnAutoIncrement: false,
+      columnDefault: false,
+      columnComment: false,
+    };
+
+    const cases: Array<[string, string, TemplateOptions]> = [
+      ['sharedFocusName', 'columnName', { sharedFocusName: PEER_COLOR }],
+      [
+        'sharedFocusDataType',
+        'columnDataType',
+        { sharedFocusDataType: PEER_COLOR },
+      ],
+      [
+        'sharedFocusAutoIncrement',
+        'columnAutoIncrement',
+        { sharedFocusAutoIncrement: PEER_COLOR },
+      ],
+    ];
+
+    it('marks no cell while every shared focus prop is false', async () => {
+      showAll(app);
+      mounted = await mountAndFlush(columnTemplate(column), app);
+
+      expect(sharedFocusMapOf(mounted)).toEqual(noSharedFocus);
+    });
+
+    for (const [prop, dataType, options] of cases) {
+      it(`marks only the ${dataType} cell from ${prop}`, async () => {
+        showAll(app);
+        mounted = await mountAndFlush(columnTemplate(column, options), app);
+
+        expect(sharedFocusMapOf(mounted)).toEqual({
+          ...noSharedFocus,
+          [dataType]: true,
+        });
+      });
+    }
+
+    it('keeps a local focus and a remote focus on their own cells', async () => {
+      showAll(app);
+      mounted = await mountAndFlush(
+        columnTemplate(column, {
+          focusName: true,
+          sharedFocusDataType: PEER_COLOR,
+        }),
+        app
+      );
+
+      expect(sharedFocusMapOf(mounted)).toEqual({
+        ...noSharedFocus,
+        columnDataType: true,
+      });
+      expect(
+        colOf(mounted, 'columnName')?.querySelector(
+          '.edit-input[data-focus-border-bottom]'
+        )
+      ).toBeTruthy();
+      expect(
+        colOf(mounted, 'columnDataType')?.querySelector(
+          '.edit-input[data-focus-border-bottom]'
+        )
+      ).toBeNull();
     });
   });
 

--- a/packages/erd-editor/src/components/erd/canvas/table/column/Column.tsx
+++ b/packages/erd-editor/src/components/erd/canvas/table/column/Column.tsx
@@ -53,6 +53,13 @@ export type ColumnProps = {
   focusComment: boolean;
   focusUnique: boolean;
   focusAutoIncrement: boolean;
+  sharedFocusName: string | null;
+  sharedFocusDataType: string | null;
+  sharedFocusNotNull: string | null;
+  sharedFocusDefault: string | null;
+  sharedFocusComment: string | null;
+  sharedFocusUnique: string | null;
+  sharedFocusAutoIncrement: string | null;
   editName: boolean;
   editDataType: boolean;
   editDefault: boolean;
@@ -153,6 +160,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnName"
+                bool:data-shared-focus={Boolean(props.sharedFocusName)}
+                style={{ '--shared-focus': props.sharedFocusName ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnName);
                 }}
@@ -180,6 +189,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnDefault"
+                bool:data-shared-focus={Boolean(props.sharedFocusDefault)}
+                style={{ '--shared-focus': props.sharedFocusDefault ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnDefault);
                 }}
@@ -207,6 +218,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnComment"
+                bool:data-shared-focus={Boolean(props.sharedFocusComment)}
+                style={{ '--shared-focus': props.sharedFocusComment ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnComment);
                 }}
@@ -235,6 +248,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnDataType"
+                bool:data-shared-focus={Boolean(props.sharedFocusDataType)}
+                style={{ '--shared-focus': props.sharedFocusDataType ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnDataType);
                 }}
@@ -264,6 +279,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnNotNull"
+                bool:data-shared-focus={Boolean(props.sharedFocusNotNull)}
+                style={{ '--shared-focus': props.sharedFocusNotNull ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnNotNull);
                 }}
@@ -283,6 +300,8 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnUnique"
+                bool:data-shared-focus={Boolean(props.sharedFocusUnique)}
+                style={{ '--shared-focus': props.sharedFocusUnique ?? '' }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnUnique);
                 }}
@@ -305,6 +324,10 @@ const Column: FC<ColumnProps> = (props, ctx) => {
               <div
                 class="column-col"
                 data-type="columnAutoIncrement"
+                bool:data-shared-focus={Boolean(props.sharedFocusAutoIncrement)}
+                style={{
+                  '--shared-focus': props.sharedFocusAutoIncrement ?? '',
+                }}
                 on:mousedown={(event: MouseEvent) => {
                   handleFocus(event, FocusType.columnAutoIncrement);
                 }}

--- a/packages/erd-editor/src/components/erd/canvas/table/useSharedFocusTable.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/useSharedFocusTable.test.ts
@@ -1,0 +1,287 @@
+import { FC, html } from '@dineug/r-html';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import {
+  createTestAppContext,
+  flush,
+  mountAndFlush,
+  Mounted,
+} from '@/__test-utils__/index';
+import { AppContext } from '@/components/appContext';
+import { useSharedFocusTable } from '@/components/erd/canvas/table/useSharedFocusTable';
+import { sharedFocusTrackerAction } from '@/engine/modules/editor/atom.actions';
+import { FocusType, SharedFocus } from '@/engine/modules/editor/state';
+import { Tag } from '@/engine/tag';
+
+type SharedFocusApi = ReturnType<typeof useSharedFocusTable>;
+
+type HostProps = {
+  tableId: string;
+  capture: (api: SharedFocusApi) => void;
+};
+
+const Host: FC<HostProps> = (props, ctx) => {
+  const api = useSharedFocusTable(ctx, props.tableId);
+  props.capture(api);
+  return () =>
+    html`<div class="host">
+      ${api.sharedFocusTableColor() ? 'shared' : 'none'}
+    </div>`;
+};
+
+let mounted: Mounted | null = null;
+const apps = new Set<AppContext>();
+
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+
+  for (const app of apps) {
+    for (const tracker of Object.values(
+      app.store.state.editor.sharedFocusTrackerMap
+    )) {
+      clearTimeout(tracker.timeoutId);
+    }
+  }
+  apps.clear();
+});
+
+const createApp = () => {
+  const app = createTestAppContext();
+  apps.add(app);
+  return app;
+};
+
+const track = (app: AppContext, editorId: string, focus: SharedFocus | null) =>
+  app.store.dispatchSync({
+    ...sharedFocusTrackerAction({ focus }),
+    tags: Tag.shared,
+    meta: { editorId },
+  });
+
+const hostTexts = () =>
+  Array.from(mounted!.container.querySelectorAll<HTMLElement>('.host')).map(
+    el => el.textContent?.trim() ?? ''
+  );
+
+type Fixture = {
+  app: AppContext;
+  tableId: string;
+  otherTableId: string;
+  api: SharedFocusApi;
+  otherApi: SharedFocusApi;
+};
+
+async function setup(): Promise<Fixture> {
+  const app = createApp();
+  const tableId = 't1';
+  const otherTableId = 't2';
+
+  let api!: SharedFocusApi;
+  let otherApi!: SharedFocusApi;
+
+  mounted = await mountAndFlush(
+    html`
+      <${Host}
+        tableId=${tableId}
+        .capture=${(value: SharedFocusApi) => (api = value)}
+      />
+      <${Host}
+        tableId=${otherTableId}
+        .capture=${(value: SharedFocusApi) => (otherApi = value)}
+      />
+    `,
+    app
+  );
+
+  return { app, tableId, otherTableId, api, otherApi };
+}
+
+describe('useSharedFocusTable', () => {
+  it('exposes the two shared focus predicates', async () => {
+    const { api } = await setup();
+
+    expect(Object.keys(api).sort()).toEqual([
+      'sharedFocusColor',
+      'sharedFocusTableColor',
+    ]);
+  });
+
+  it('reports nothing while the tracker map is empty', async () => {
+    const { app, api } = await setup();
+
+    expect(app.store.state.editor.sharedFocusTrackerMap).toEqual({});
+    expect(api.sharedFocusTableColor()).toBeNull();
+
+    for (const focusType of Object.values(FocusType)) {
+      expect(api.sharedFocusColor(focusType)).toBeNull();
+      expect(api.sharedFocusColor(focusType, 'c1')).toBeNull();
+    }
+  });
+
+  it('ignores a tracker focused on another table', async () => {
+    const { app, otherTableId, api } = await setup();
+
+    track(app, 'remote-1', {
+      tableId: otherTableId,
+      columnId: 'c1',
+      focusType: FocusType.columnName,
+    });
+
+    expect(api.sharedFocusTableColor()).toBeNull();
+    expect(api.sharedFocusColor(FocusType.columnName, 'c1')).toBeNull();
+    expect(api.sharedFocusColor(FocusType.tableName)).toBeNull();
+  });
+
+  it('matches a shared column focus only for that column id', async () => {
+    const { app, tableId, api } = await setup();
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: 'c1',
+      focusType: FocusType.columnName,
+    });
+
+    expect(api.sharedFocusTableColor()).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.columnName, 'c1')).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.columnName, 'c2')).toBeNull();
+    expect(api.sharedFocusColor(FocusType.columnDataType, 'c1')).toBeNull();
+  });
+
+  it('matches a shared table focus whatever column id is asked for', async () => {
+    const { app, tableId, api } = await setup();
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+
+    expect(api.sharedFocusTableColor()).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.tableName)).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.tableName, 'c1')).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.tableComment)).toBeNull();
+  });
+
+  it('lights up each table for the peer that focused it', async () => {
+    const { app, tableId, otherTableId, api, otherApi } = await setup();
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: 'c1',
+      focusType: FocusType.columnName,
+    });
+    track(app, 'remote-2', {
+      tableId: otherTableId,
+      columnId: null,
+      focusType: FocusType.tableComment,
+    });
+
+    expect(api.sharedFocusTableColor()).not.toBeNull();
+    expect(otherApi.sharedFocusTableColor()).not.toBeNull();
+
+    expect(api.sharedFocusColor(FocusType.columnName, 'c1')).not.toBeNull();
+    expect(api.sharedFocusColor(FocusType.tableComment)).toBeNull();
+
+    expect(otherApi.sharedFocusColor(FocusType.tableComment)).not.toBeNull();
+    expect(otherApi.sharedFocusColor(FocusType.columnName, 'c1')).toBeNull();
+  });
+
+  it('re-renders when a peer key is added to the map after the first render', async () => {
+    const { app, tableId } = await setup();
+
+    expect(hostTexts()).toEqual(['none', 'none']);
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: 'c1',
+      focusType: FocusType.columnName,
+    });
+    await flush();
+
+    expect(hostTexts()).toEqual(['shared', 'none']);
+  });
+
+  it('re-renders when the peer moves its focus to the other table', async () => {
+    const { app, tableId, otherTableId } = await setup();
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+    expect(hostTexts()).toEqual(['shared', 'none']);
+
+    track(app, 'remote-1', {
+      tableId: otherTableId,
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+
+    expect(hostTexts()).toEqual(['none', 'shared']);
+  });
+
+  it('re-renders when the peer clears its focus', async () => {
+    const { app, tableId, api } = await setup();
+
+    track(app, 'remote-1', {
+      tableId,
+      columnId: 'c1',
+      focusType: FocusType.columnName,
+    });
+    await flush();
+    expect(hostTexts()).toEqual(['shared', 'none']);
+
+    track(app, 'remote-1', null);
+    await flush();
+
+    expect(api.sharedFocusTableColor()).toBeNull();
+    expect(hostTexts()).toEqual(['none', 'none']);
+  });
+
+  it('leaves a peer update harmless once unmounted', async () => {
+    const { app, tableId } = await setup();
+    const container = mounted!.container;
+
+    mounted!.unmount();
+    mounted = null;
+
+    expect(() =>
+      track(app, 'remote-1', {
+        tableId,
+        columnId: null,
+        focusType: FocusType.tableName,
+      })
+    ).not.toThrow();
+    await flush();
+
+    expect(container.querySelectorAll('.host')).toHaveLength(0);
+  });
+
+  it('keeps a second host reactive after the first one unmounts', async () => {
+    const app = createApp();
+
+    const first = await mountAndFlush(
+      html`<${Host} tableId=${'t1'} .capture=${() => {}} />`,
+      app
+    );
+    mounted = await mountAndFlush(
+      html`<${Host} tableId=${'t1'} .capture=${() => {}} />`,
+      app
+    );
+    expect(hostTexts()).toEqual(['none']);
+
+    first.unmount();
+
+    track(app, 'remote-1', {
+      tableId: 't1',
+      columnId: null,
+      focusType: FocusType.tableName,
+    });
+    await flush();
+
+    expect(hostTexts()).toEqual(['shared']);
+  });
+});

--- a/packages/erd-editor/src/components/erd/canvas/table/useSharedFocusTable.ts
+++ b/packages/erd-editor/src/components/erd/canvas/table/useSharedFocusTable.ts
@@ -1,0 +1,53 @@
+import { observable, onMounted, watch } from '@dineug/r-html';
+
+import { useAppContext } from '@/components/appContext';
+import { FocusType } from '@/engine/modules/editor/state';
+import { useUnmounted } from '@/hooks/useUnmounted';
+import { Ctx } from '@/internal-types';
+import { isFocus } from '@/utils/focus';
+import { toSharedColor } from '@/utils/sharedColor';
+
+export function useSharedFocusTable(ctx: Ctx, tableId: string) {
+  const app = useAppContext(ctx);
+  const { addUnsubscribe } = useUnmounted();
+  const state = observable({ force: false });
+
+  const forceUpdate = () => {
+    state.force = !state.force;
+  };
+
+  onMounted(() => {
+    const { store } = app.value;
+    const {
+      editor: { sharedFocusTrackerMap },
+    } = store.state;
+
+    addUnsubscribe(watch(sharedFocusTrackerMap).subscribe(forceUpdate));
+  });
+
+  const getTrackers = () => {
+    const { store } = app.value;
+
+    // observable dependency
+    state.force;
+
+    return Object.values(store.state.editor.sharedFocusTrackerMap);
+  };
+
+  const sharedFocusTableColor = () => {
+    const tracker = getTrackers().find(tracker => tracker.tableId === tableId);
+    return tracker ? toSharedColor(tracker.id) : null;
+  };
+
+  const sharedFocusColor = (focusType: FocusType, columnId?: string) => {
+    const tracker = getTrackers().find(tracker =>
+      isFocus(tracker, focusType, tableId, columnId)
+    );
+    return tracker ? toSharedColor(tracker.id) : null;
+  };
+
+  return {
+    sharedFocusTableColor,
+    sharedFocusColor,
+  };
+}

--- a/packages/erd-editor/src/components/erd/canvas/useSharedSelectEntity.test.ts
+++ b/packages/erd-editor/src/components/erd/canvas/useSharedSelectEntity.test.ts
@@ -1,0 +1,221 @@
+import { FC, html } from '@dineug/r-html';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import {
+  createTestAppContext,
+  flush,
+  mountAndFlush,
+  Mounted,
+} from '@/__test-utils__/index';
+import { AppContext } from '@/components/appContext';
+import { useSharedSelectEntity } from '@/components/erd/canvas/useSharedSelectEntity';
+import { sharedSelectionTrackerAction } from '@/engine/modules/editor/atom.actions';
+import { Tag } from '@/engine/tag';
+import { toSharedColor } from '@/utils/sharedColor';
+
+type SharedSelectApi = ReturnType<typeof useSharedSelectEntity>;
+
+type HostProps = {
+  entityId: string;
+  capture: (api: SharedSelectApi) => void;
+};
+
+const Host: FC<HostProps> = (props, ctx) => {
+  const api = useSharedSelectEntity(ctx, props.entityId);
+  props.capture(api);
+  return () =>
+    html`<div class="host">${api.sharedSelectColor() ?? 'none'}</div>`;
+};
+
+let mounted: Mounted | null = null;
+const apps = new Set<AppContext>();
+
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+
+  for (const app of apps) {
+    for (const tracker of Object.values(
+      app.store.state.editor.sharedSelectionTrackerMap
+    )) {
+      clearTimeout(tracker.timeoutId);
+    }
+  }
+  apps.clear();
+});
+
+const createApp = () => {
+  const app = createTestAppContext();
+  apps.add(app);
+  return app;
+};
+
+const track = (app: AppContext, editorId: string, selectedIds: string[]) =>
+  app.store.dispatchSync({
+    ...sharedSelectionTrackerAction({ selectedIds }),
+    tags: Tag.shared,
+    meta: { editorId },
+  });
+
+const hostTexts = () =>
+  Array.from(mounted!.container.querySelectorAll<HTMLElement>('.host')).map(
+    el => el.textContent?.trim() ?? ''
+  );
+
+type Fixture = {
+  app: AppContext;
+  tableId: string;
+  memoId: string;
+  api: SharedSelectApi;
+  memoApi: SharedSelectApi;
+};
+
+async function setup(): Promise<Fixture> {
+  const app = createApp();
+  const tableId = 't1';
+  const memoId = 'm1';
+
+  let api!: SharedSelectApi;
+  let memoApi!: SharedSelectApi;
+
+  mounted = await mountAndFlush(
+    html`
+      <${Host}
+        entityId=${tableId}
+        .capture=${(value: SharedSelectApi) => (api = value)}
+      />
+      <${Host}
+        entityId=${memoId}
+        .capture=${(value: SharedSelectApi) => (memoApi = value)}
+      />
+    `,
+    app
+  );
+
+  return { app, tableId, memoId, api, memoApi };
+}
+
+describe('useSharedSelectEntity', () => {
+  it('exposes the shared select color accessor', async () => {
+    const { api } = await setup();
+
+    expect(Object.keys(api)).toEqual(['sharedSelectColor']);
+  });
+
+  it('reports nothing while the tracker map is empty', async () => {
+    const { app, api, memoApi } = await setup();
+
+    expect(app.store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(api.sharedSelectColor()).toBeNull();
+    expect(memoApi.sharedSelectColor()).toBeNull();
+  });
+
+  it('returns the peer color for an entity inside its selection', async () => {
+    const { app, tableId, api } = await setup();
+
+    track(app, 'remote-1', [tableId]);
+
+    expect(api.sharedSelectColor()).toBe(toSharedColor('remote-1'));
+  });
+
+  it('ignores a peer whose selection leaves this entity out', async () => {
+    const { app, memoId, api } = await setup();
+
+    track(app, 'remote-1', [memoId, 'other']);
+
+    expect(api.sharedSelectColor()).toBeNull();
+  });
+
+  it('lights up a table and a memo from one peer selection', async () => {
+    const { app, tableId, memoId, api, memoApi } = await setup();
+
+    track(app, 'remote-1', [memoId, tableId]);
+
+    expect(api.sharedSelectColor()).toBe(toSharedColor('remote-1'));
+    expect(memoApi.sharedSelectColor()).toBe(toSharedColor('remote-1'));
+  });
+
+  it('lights up each entity with the color of the peer that selected it', async () => {
+    const { app, tableId, memoId, api, memoApi } = await setup();
+
+    track(app, 'remote-1', [tableId]);
+    track(app, 'remote-2', [memoId]);
+
+    expect(api.sharedSelectColor()).toBe(toSharedColor('remote-1'));
+    expect(memoApi.sharedSelectColor()).toBe(toSharedColor('remote-2'));
+    expect(toSharedColor('remote-1')).not.toBe(toSharedColor('remote-2'));
+  });
+
+  it('re-renders when a peer key is added to the map after the first render', async () => {
+    const { app, tableId } = await setup();
+
+    expect(hostTexts()).toEqual(['none', 'none']);
+
+    track(app, 'remote-1', [tableId]);
+    await flush();
+
+    expect(hostTexts()).toEqual([toSharedColor('remote-1'), 'none']);
+  });
+
+  it('re-renders when the peer moves its selection to the other entity', async () => {
+    const { app, tableId, memoId } = await setup();
+
+    track(app, 'remote-1', [tableId]);
+    await flush();
+    expect(hostTexts()).toEqual([toSharedColor('remote-1'), 'none']);
+
+    track(app, 'remote-1', [memoId]);
+    await flush();
+
+    expect(hostTexts()).toEqual(['none', toSharedColor('remote-1')]);
+  });
+
+  it('re-renders when the peer entry is deleted by an empty selection', async () => {
+    const { app, tableId, api } = await setup();
+
+    track(app, 'remote-1', [tableId]);
+    await flush();
+    expect(hostTexts()).toEqual([toSharedColor('remote-1'), 'none']);
+
+    track(app, 'remote-1', []);
+    await flush();
+
+    expect(app.store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(api.sharedSelectColor()).toBeNull();
+    expect(hostTexts()).toEqual(['none', 'none']);
+  });
+
+  it('leaves a peer update harmless once unmounted', async () => {
+    const { app, tableId } = await setup();
+    const container = mounted!.container;
+
+    mounted!.unmount();
+    mounted = null;
+
+    expect(() => track(app, 'remote-1', [tableId])).not.toThrow();
+    await flush();
+
+    expect(container.querySelectorAll('.host')).toHaveLength(0);
+  });
+
+  it('keeps a second host reactive after the first one unmounts', async () => {
+    const app = createApp();
+
+    const first = await mountAndFlush(
+      html`<${Host} entityId=${'t1'} .capture=${() => {}} />`,
+      app
+    );
+    mounted = await mountAndFlush(
+      html`<${Host} entityId=${'t1'} .capture=${() => {}} />`,
+      app
+    );
+    expect(hostTexts()).toEqual(['none']);
+
+    first.unmount();
+
+    track(app, 'remote-1', ['t1']);
+    await flush();
+
+    expect(hostTexts()).toEqual([toSharedColor('remote-1')]);
+  });
+});

--- a/packages/erd-editor/src/components/erd/canvas/useSharedSelectEntity.ts
+++ b/packages/erd-editor/src/components/erd/canvas/useSharedSelectEntity.ts
@@ -1,0 +1,42 @@
+import { observable, onMounted, watch } from '@dineug/r-html';
+
+import { useAppContext } from '@/components/appContext';
+import { useUnmounted } from '@/hooks/useUnmounted';
+import { Ctx } from '@/internal-types';
+import { toSharedColor } from '@/utils/sharedColor';
+
+export function useSharedSelectEntity(ctx: Ctx, entityId: string) {
+  const app = useAppContext(ctx);
+  const { addUnsubscribe } = useUnmounted();
+  const state = observable({ force: false });
+
+  const forceUpdate = () => {
+    state.force = !state.force;
+  };
+
+  onMounted(() => {
+    const { store } = app.value;
+    const {
+      editor: { sharedSelectionTrackerMap },
+    } = store.state;
+
+    addUnsubscribe(watch(sharedSelectionTrackerMap).subscribe(forceUpdate));
+  });
+
+  const sharedSelectColor = () => {
+    const { store } = app.value;
+
+    // observable dependency
+    state.force;
+
+    const tracker = Object.values(
+      store.state.editor.sharedSelectionTrackerMap
+    ).find(tracker => tracker.selectedIds.includes(entityId));
+
+    return tracker ? toSharedColor(tracker.id) : null;
+  };
+
+  return {
+    sharedSelectColor,
+  };
+}

--- a/packages/erd-editor/src/components/erd/drag-select/DragSelect.test.ts
+++ b/packages/erd-editor/src/components/erd/drag-select/DragSelect.test.ts
@@ -17,12 +17,14 @@ import {
 import { AppContext } from '@/components/appContext';
 import DragSelect from '@/components/erd/drag-select/DragSelect';
 import * as styles from '@/components/erd/drag-select/DragSelect.styles';
+import { dragSelectRectAction } from '@/engine/modules/editor/atom.actions';
 import { SelectType } from '@/engine/modules/editor/state';
 import {
   changeZoomLevelAction,
   scrollToAction,
 } from '@/engine/modules/settings/atom.actions';
 import { addTableAction } from '@/engine/modules/table/atom.actions';
+import { Rect } from '@/utils/dragSelect';
 
 // happy-dom measures everything as 0x0 at (0, 0); the root gets a deliberate
 // origin so the component has to subtract it from the pointer position.
@@ -68,6 +70,17 @@ const rect = () =>
 // An empty table renders 365x56, so its 15x15 center box sits at (167.5, 13).
 const seedTable = (id: string, x = 0, y = 0) => {
   app.store.dispatchSync(addTableAction({ id, ui: { x, y, zIndex: 2 } }));
+};
+
+const recordDragSelectRects = () => {
+  const rects: Array<Rect | null> = [];
+  const unsubscribe = app.store.subscribe(actions => {
+    actions.forEach(action => {
+      action.type === dragSelectRectAction.type &&
+        rects.push(action.payload.rect);
+    });
+  });
+  return { rects, unsubscribe };
 };
 
 beforeEach(() => {
@@ -232,6 +245,79 @@ describe('DragSelect', () => {
     await flush();
 
     expect(app.store.state.editor.selectedMap).toEqual({});
+  });
+
+  it('shares the dragged rect on every move', async () => {
+    mounted = await mount(0, 0);
+    const { rects, unsubscribe } = recordDragSelectRects();
+
+    moveTo(300, 300);
+    await flush();
+    moveTo(120, 90);
+    await flush();
+    unsubscribe();
+
+    expect(rects).toEqual([
+      { x: 0, y: 0, w: 300, h: 300 },
+      { x: 0, y: 0, w: 120, h: 90 },
+    ]);
+    expect(app.store.state.editor.dragSelect).toEqual({
+      x: 0,
+      y: 0,
+      w: 120,
+      h: 90,
+    });
+  });
+
+  it('shares the same absolute rect the selection was computed from', async () => {
+    seedTable('t1', 0, 0);
+    seedTable('t2', -800, -800);
+    app.store.dispatchSync(changeZoomLevelAction({ value: 0.5 }));
+    mounted = await mount(0, 0);
+    const { rects, unsubscribe } = recordDragSelectRects();
+
+    moveTo(300, 300);
+    await flush();
+    unsubscribe();
+
+    // The same -1000..-400 canvas rect the selection above is derived from,
+    // not the 0..300 screen box the svg is drawn with.
+    const shared = { x: -1000, y: -1000, w: 600, h: 600 };
+    expect(rects).toEqual([shared]);
+    expect(app.store.state.editor.dragSelect).toEqual(shared);
+    expect(app.store.state.editor.selectedMap).toEqual({
+      t2: SelectType.table,
+    });
+  });
+
+  it('shares the rect shifted by the canvas scroll', async () => {
+    app.store.dispatchSync(
+      scrollToAction({ scrollLeft: -100, scrollTop: -100 })
+    );
+    mounted = await mount(0, 0);
+    const { rects, unsubscribe } = recordDragSelectRects();
+
+    moveTo(300, 300);
+    await flush();
+    unsubscribe();
+
+    expect(rects).toEqual([{ x: 100, y: 100, w: 300, h: 300 }]);
+  });
+
+  it('clears the shared rect when the drag ends by unmount', async () => {
+    mounted = await mount(0, 0);
+    moveTo(300, 300);
+    await flush();
+    expect(app.store.state.editor.dragSelect).not.toBeNull();
+
+    const { rects, unsubscribe } = recordDragSelectRects();
+    mounted.unmount();
+    mounted = null;
+    await flush();
+    unsubscribe();
+
+    expect(rects).toEqual([null]);
+    expect(app.store.state.editor.dragSelect).toBeNull();
   });
 
   it('reports the end of the drag on the global mouseup', async () => {

--- a/packages/erd-editor/src/components/erd/drag-select/DragSelect.tsx
+++ b/packages/erd-editor/src/components/erd/drag-select/DragSelect.tsx
@@ -2,6 +2,7 @@ import { FC, observable, onBeforeMount, Ref } from '@dineug/r-html';
 import { fromEvent } from 'rxjs';
 
 import { useAppContext } from '@/components/appContext';
+import { dragSelectRectAction } from '@/engine/modules/editor/atom.actions';
 import { dragSelectAction$ } from '@/engine/modules/editor/generator.actions';
 import { useUnmounted } from '@/hooks/useUnmounted';
 import { getAbsolutePoint } from '@/utils/dragSelect';
@@ -26,6 +27,7 @@ const DragSelect: FC<DragSelectProps> = (props, ctx) => {
     const $root = props.root.value;
 
     addUnsubscribe(
+      () => store.dispatchSync(dragSelectRectAction({ rect: null })),
       mouseup$.subscribe(props.onDragSelectEnd),
       fromEvent<MouseEvent>($root, 'mousemove').subscribe(event => {
         event.preventDefault();
@@ -77,12 +79,15 @@ const DragSelect: FC<DragSelectProps> = (props, ctx) => {
           zoomLevel
         );
 
+        const dragRect = {
+          ...absoluteMin,
+          w: absoluteMax.x - absoluteMin.x,
+          h: absoluteMax.y - absoluteMin.y,
+        };
+
         store.dispatch(
-          dragSelectAction$({
-            ...absoluteMin,
-            w: absoluteMax.x - absoluteMin.x,
-            h: absoluteMax.y - absoluteMin.y,
-          })
+          dragSelectAction$(dragRect),
+          dragSelectRectAction({ rect: dragRect })
         );
       })
     );

--- a/packages/erd-editor/src/engine/actions.test.ts
+++ b/packages/erd-editor/src/engine/actions.test.ts
@@ -171,8 +171,13 @@ describe('ReadonlyIgnoreActionTypes', () => {
 });
 
 describe('shared action types', () => {
-  it('SharedStreamActionTypes tracks only the mouse tracker', () => {
-    expect(SharedStreamActionTypes).toEqual(['editor.sharedMouseTracker']);
+  it('SharedStreamActionTypes tracks the ephemeral presence streams', () => {
+    expect(SharedStreamActionTypes).toEqual([
+      'editor.sharedMouseTracker',
+      'editor.sharedFocusTracker',
+      'editor.sharedSelectionTracker',
+      'editor.sharedDragSelectTracker',
+    ]);
   });
 
   it('SharedActionTypes is ChangeActionTypes plus stream and LWW sync', () => {

--- a/packages/erd-editor/src/engine/actions.ts
+++ b/packages/erd-editor/src/engine/actions.ts
@@ -163,6 +163,9 @@ export const ReadonlyIgnoreActionTypes: ReadonlyArray<ActionType> = [
 
 export const SharedStreamActionTypes: ReadonlyArray<ActionType> = [
   'editor.sharedMouseTracker',
+  'editor.sharedFocusTracker',
+  'editor.sharedSelectionTracker',
+  'editor.sharedDragSelectTracker',
 ];
 
 export const SharedActionTypes: ReadonlyArray<ActionType> = [

--- a/packages/erd-editor/src/engine/modules/editor/actions.ts
+++ b/packages/erd-editor/src/engine/modules/editor/actions.ts
@@ -3,8 +3,9 @@ import { Reducer } from '@dineug/r-html';
 import { EngineContext } from '@/engine/context';
 import { RootState } from '@/engine/state';
 import { type LWW, ValuesType } from '@/internal-types';
+import { Rect } from '@/utils/dragSelect';
 
-import { FocusType, MoveKey, SelectType } from './state';
+import { FocusType, MoveKey, SelectType, SharedFocus } from './state';
 
 export const ActionType = {
   changeHasHistory: 'editor.changeHasHistory',
@@ -33,6 +34,10 @@ export const ActionType = {
   dragstartColumn: 'editor.dragstartColumn',
   dragendColumn: 'editor.dragendColumn',
   sharedMouseTracker: 'editor.sharedMouseTracker',
+  sharedFocusTracker: 'editor.sharedFocusTracker',
+  sharedSelectionTracker: 'editor.sharedSelectionTracker',
+  sharedDragSelectTracker: 'editor.sharedDragSelectTracker',
+  dragSelectRect: 'editor.dragSelectRect',
   validationIds: 'editor.validationIds',
   getLWW: 'editor.getLWW',
   mergeLWW: 'editor.mergeLWW',
@@ -104,6 +109,18 @@ export type ActionMap = {
   [ActionType.sharedMouseTracker]: {
     x: number;
     y: number;
+  };
+  [ActionType.sharedFocusTracker]: {
+    focus: SharedFocus | null;
+  };
+  [ActionType.sharedSelectionTracker]: {
+    selectedIds: string[];
+  };
+  [ActionType.sharedDragSelectTracker]: {
+    rect: Rect | null;
+  };
+  [ActionType.dragSelectRect]: {
+    rect: Rect | null;
   };
   [ActionType.validationIds]: void;
   [ActionType.getLWW]: void;

--- a/packages/erd-editor/src/engine/modules/editor/atom.actions.test.ts
+++ b/packages/erd-editor/src/engine/modules/editor/atom.actions.test.ts
@@ -16,6 +16,7 @@ import {
   changeViewportAction,
   clearAction,
   dragendColumnAction,
+  dragSelectRectAction,
   dragstartColumnAction,
   drawEndRelationshipAction,
   drawRelationshipAction,
@@ -37,11 +38,20 @@ import {
   selectAction,
   selectAllAction,
   selectAllColumnAction,
+  SHARED_DRAG_SELECT_TRACKER_TIMEOUT,
+  sharedDragSelectTrackerAction,
+  sharedFocusTrackerAction,
   sharedMouseTrackerAction,
+  sharedSelectionTrackerAction,
   unselectAllAction,
   validationIdsAction,
 } from '@/engine/modules/editor/atom.actions';
-import { FocusType, MoveKey, SelectType } from '@/engine/modules/editor/state';
+import {
+  FocusType,
+  MoveKey,
+  SelectType,
+  type SharedFocus,
+} from '@/engine/modules/editor/state';
 import { createStore, Store } from '@/engine/store';
 import { Tag } from '@/engine/tag';
 import { createIndex } from '@/utils/collection/index.entity';
@@ -50,6 +60,7 @@ import { createMemo } from '@/utils/collection/memo.entity';
 import { createRelationship } from '@/utils/collection/relationship.entity';
 import { createTable } from '@/utils/collection/table.entity';
 import { createColumn } from '@/utils/collection/tableColumn.entity';
+import { type Rect } from '@/utils/dragSelect';
 
 function createTestStore(enableObservable = true): Store {
   return createStore(
@@ -868,6 +879,434 @@ describe('editor.sharedMouseTracker', () => {
 
     vi.advanceTimersByTime(11_000);
     expect(store.state.editor.sharedMouseTrackerMap.remote).toBeUndefined();
+  });
+});
+
+describe('editor.sharedFocusTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const track = (
+    focus: SharedFocus | null,
+    { tags, meta }: { tags?: number; meta?: Record<string, any> } = {}
+  ) =>
+    store.dispatchSync({
+      ...sharedFocusTrackerAction({ focus }),
+      tags,
+      meta,
+    });
+
+  const tableNameFocus: SharedFocus = {
+    tableId: 't1',
+    columnId: null,
+    focusType: FocusType.tableName,
+  };
+
+  it('ignores actions without tags', () => {
+    track(tableNameFocus, { meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('ignores actions that are not tagged as shared', () => {
+    track(tableNameFocus, {
+      tags: Tag.changeOnly,
+      meta: { editorId: 'remote' },
+    });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('ignores actions without a string editorId', () => {
+    track(tableNameFocus, { tags: Tag.shared, meta: { editorId: 42 } });
+    track(tableNameFocus, { tags: Tag.shared });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('ignores its own editor id', () => {
+    track(tableNameFocus, {
+      tags: Tag.shared,
+      meta: { editorId: store.state.editor.id },
+    });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('creates a tracker without a nickname', () => {
+    track(
+      {
+        tableId: 't1',
+        columnId: 'c1',
+        focusType: FocusType.columnDataType,
+      },
+      { tags: Tag.shared, meta: { editorId: 'remote', nickname: 'kim' } }
+    );
+
+    const tracker = store.state.editor.sharedFocusTrackerMap.remote;
+    expect(tracker.id).toBe('remote');
+    expect(tracker.tableId).toBe('t1');
+    expect(tracker.columnId).toBe('c1');
+    expect(tracker.focusType).toBe(FocusType.columnDataType);
+    expect(Object.keys(tracker).sort()).toEqual([
+      'columnId',
+      'focusType',
+      'id',
+      'tableId',
+      'timeoutId',
+    ]);
+  });
+
+  it('updates an existing tracker in place', () => {
+    track(tableNameFocus, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    track(
+      {
+        tableId: 't2',
+        columnId: 'c9',
+        focusType: FocusType.columnComment,
+      },
+      { tags: Tag.shared, meta: { editorId: 'remote' } }
+    );
+
+    expect(Object.keys(store.state.editor.sharedFocusTrackerMap)).toEqual([
+      'remote',
+    ]);
+    const tracker = store.state.editor.sharedFocusTrackerMap.remote;
+    expect(tracker.tableId).toBe('t2');
+    expect(tracker.columnId).toBe('c9');
+    expect(tracker.focusType).toBe(FocusType.columnComment);
+  });
+
+  it('deletes the tracker on a null focus', () => {
+    track(tableNameFocus, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedFocusTrackerMap.remote).toBeDefined();
+
+    track(null, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('ignores a null focus for an unknown editor id', () => {
+    track(null, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedFocusTrackerMap).toEqual({});
+  });
+
+  it('drops the tracker after 90s without a heartbeat', () => {
+    track(tableNameFocus, { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    vi.advanceTimersByTime(89_999);
+    expect(store.state.editor.sharedFocusTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(2);
+    expect(store.state.editor.sharedFocusTrackerMap.remote).toBeUndefined();
+  });
+
+  it('restarts the expiry timer on every update', () => {
+    track(tableNameFocus, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    vi.advanceTimersByTime(60_000);
+
+    track(
+      {
+        tableId: 't1',
+        columnId: 'c1',
+        focusType: FocusType.columnName,
+      },
+      { tags: Tag.shared, meta: { editorId: 'remote' } }
+    );
+    vi.advanceTimersByTime(60_000);
+    expect(store.state.editor.sharedFocusTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(31_000);
+    expect(store.state.editor.sharedFocusTrackerMap.remote).toBeUndefined();
+  });
+});
+
+describe('editor.sharedSelectionTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const track = (
+    selectedIds: string[],
+    { tags, meta }: { tags?: number; meta?: Record<string, any> } = {}
+  ) =>
+    store.dispatchSync({
+      ...sharedSelectionTrackerAction({ selectedIds }),
+      tags,
+      meta,
+    });
+
+  it('ignores actions without tags', () => {
+    track(['t1'], { meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+  });
+
+  it('ignores actions that are not tagged as shared', () => {
+    track(['t1'], {
+      tags: Tag.changeOnly,
+      meta: { editorId: 'remote' },
+    });
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+  });
+
+  it('ignores actions without a string editorId', () => {
+    track(['t1'], { tags: Tag.shared, meta: { editorId: 42 } });
+    track(['t1'], { tags: Tag.shared });
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+  });
+
+  it('ignores its own editor id', () => {
+    track(['t1'], {
+      tags: Tag.shared,
+      meta: { editorId: store.state.editor.id },
+    });
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+  });
+
+  it('creates a tracker holding the selected ids', () => {
+    track(['m1', 't1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    const tracker = store.state.editor.sharedSelectionTrackerMap.remote;
+    expect(tracker.id).toBe('remote');
+    expect(tracker.selectedIds).toEqual(['m1', 't1']);
+    expect(Object.keys(tracker).sort()).toEqual([
+      'id',
+      'selectedIds',
+      'timeoutId',
+    ]);
+  });
+
+  it('replaces the id array instead of mutating it in place', () => {
+    track(['t1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+    const before =
+      store.state.editor.sharedSelectionTrackerMap.remote.selectedIds;
+
+    track(['t1', 'm1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    expect(Object.keys(store.state.editor.sharedSelectionTrackerMap)).toEqual([
+      'remote',
+    ]);
+    const tracker = store.state.editor.sharedSelectionTrackerMap.remote;
+    expect(tracker.selectedIds).toEqual(['t1', 'm1']);
+    expect(tracker.selectedIds).not.toBe(before);
+    expect(before).toEqual(['t1']);
+  });
+
+  it('deletes the tracker on an empty selection', () => {
+    track(['t1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedSelectionTrackerMap.remote).toBeDefined();
+
+    track([], { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('ignores an empty selection for an unknown editor id', () => {
+    track([], { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedSelectionTrackerMap).toEqual({});
+  });
+
+  it('keeps two peers with overlapping selections apart', () => {
+    track(['t1', 't2'], { tags: Tag.shared, meta: { editorId: 'remote-1' } });
+    track(['m1', 't2'], { tags: Tag.shared, meta: { editorId: 'remote-2' } });
+
+    const map = store.state.editor.sharedSelectionTrackerMap;
+    expect(Object.keys(map).sort()).toEqual(['remote-1', 'remote-2']);
+    expect(map['remote-1'].selectedIds).toEqual(['t1', 't2']);
+    expect(map['remote-2'].selectedIds).toEqual(['m1', 't2']);
+
+    track([], { tags: Tag.shared, meta: { editorId: 'remote-1' } });
+
+    expect(Object.keys(map)).toEqual(['remote-2']);
+    expect(map['remote-2'].selectedIds).toEqual(['m1', 't2']);
+  });
+
+  it('drops the tracker after 90s without a heartbeat', () => {
+    track(['t1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    vi.advanceTimersByTime(89_999);
+    expect(store.state.editor.sharedSelectionTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(2);
+    expect(store.state.editor.sharedSelectionTrackerMap.remote).toBeUndefined();
+  });
+
+  it('restarts the expiry timer on every update', () => {
+    track(['t1'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+    vi.advanceTimersByTime(60_000);
+
+    track(['t1', 't2'], { tags: Tag.shared, meta: { editorId: 'remote' } });
+    vi.advanceTimersByTime(60_000);
+    expect(store.state.editor.sharedSelectionTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(31_000);
+    expect(store.state.editor.sharedSelectionTrackerMap.remote).toBeUndefined();
+  });
+});
+
+describe('editor.sharedDragSelectTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const track = (
+    rect: Rect | null,
+    { tags, meta }: { tags?: number; meta?: Record<string, any> } = {}
+  ) =>
+    store.dispatchSync({
+      ...sharedDragSelectTrackerAction({ rect }),
+      tags,
+      meta,
+    });
+
+  const dragRect: Rect = { x: 10, y: 20, w: 30, h: 40 };
+
+  it('ignores actions without tags', () => {
+    track(dragRect, { meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('ignores actions that are not tagged as shared', () => {
+    track(dragRect, {
+      tags: Tag.changeOnly,
+      meta: { editorId: 'remote' },
+    });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('ignores actions without a string editorId', () => {
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 42 } });
+    track(dragRect, { tags: Tag.shared });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('ignores its own editor id', () => {
+    track(dragRect, {
+      tags: Tag.shared,
+      meta: { editorId: store.state.editor.id },
+    });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('creates a tracker carrying the rect', () => {
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    const tracker = store.state.editor.sharedDragSelectTrackerMap.remote;
+    expect(tracker.id).toBe('remote');
+    expect(tracker.x).toBe(10);
+    expect(tracker.y).toBe(20);
+    expect(tracker.w).toBe(30);
+    expect(tracker.h).toBe(40);
+    expect(Object.keys(tracker).sort()).toEqual([
+      'h',
+      'id',
+      'timeoutId',
+      'w',
+      'x',
+      'y',
+    ]);
+  });
+
+  it('updates an existing tracker in place', () => {
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    track(
+      { x: -5, y: -6, w: 7, h: 8 },
+      { tags: Tag.shared, meta: { editorId: 'remote' } }
+    );
+
+    expect(Object.keys(store.state.editor.sharedDragSelectTrackerMap)).toEqual([
+      'remote',
+    ]);
+    const tracker = store.state.editor.sharedDragSelectTrackerMap.remote;
+    expect(tracker.x).toBe(-5);
+    expect(tracker.y).toBe(-6);
+    expect(tracker.w).toBe(7);
+    expect(tracker.h).toBe(8);
+  });
+
+  it('deletes the tracker on a null rect', () => {
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedDragSelectTrackerMap.remote).toBeDefined();
+
+    track(null, { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('ignores a null rect for an unknown editor id', () => {
+    track(null, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('drops the tracker after 3s without a heartbeat', () => {
+    expect(SHARED_DRAG_SELECT_TRACKER_TIMEOUT).toBe(3_000);
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 'remote' } });
+
+    vi.advanceTimersByTime(SHARED_DRAG_SELECT_TRACKER_TIMEOUT - 1);
+    expect(store.state.editor.sharedDragSelectTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(2);
+    expect(
+      store.state.editor.sharedDragSelectTrackerMap.remote
+    ).toBeUndefined();
+  });
+
+  it('restarts the expiry timer on every update', () => {
+    track(dragRect, { tags: Tag.shared, meta: { editorId: 'remote' } });
+    vi.advanceTimersByTime(2_000);
+
+    track(
+      { x: 1, y: 2, w: 3, h: 4 },
+      { tags: Tag.shared, meta: { editorId: 'remote' } }
+    );
+    vi.advanceTimersByTime(2_000);
+    expect(store.state.editor.sharedDragSelectTrackerMap.remote).toBeDefined();
+
+    vi.advanceTimersByTime(1_001);
+    expect(
+      store.state.editor.sharedDragSelectTrackerMap.remote
+    ).toBeUndefined();
+  });
+});
+
+describe('editor.dragSelectRect', () => {
+  it('sets the local rect from an untagged action', () => {
+    store.dispatchSync(
+      dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+    );
+
+    expect(store.state.editor.dragSelect).toEqual({ x: 1, y: 2, w: 3, h: 4 });
+    expect(store.state.editor.sharedDragSelectTrackerMap).toEqual({});
+  });
+
+  it('sets the local rect even when the action carries its own editor id', () => {
+    store.dispatchSync({
+      ...dragSelectRectAction({ rect: { x: 5, y: 6, w: 7, h: 8 } }),
+      tags: Tag.shared,
+      meta: { editorId: store.state.editor.id },
+    });
+
+    expect(store.state.editor.dragSelect).toEqual({ x: 5, y: 6, w: 7, h: 8 });
+  });
+
+  it('clears the local rect on a null rect', () => {
+    store.dispatchSync(
+      dragSelectRectAction({ rect: { x: 1, y: 2, w: 3, h: 4 } })
+    );
+
+    store.dispatchSync(dragSelectRectAction({ rect: null }));
+
+    expect(store.state.editor.dragSelect).toBeNull();
   });
 });
 

--- a/packages/erd-editor/src/engine/modules/editor/atom.actions.ts
+++ b/packages/erd-editor/src/engine/modules/editor/atom.actions.ts
@@ -27,6 +27,8 @@ import {
 } from './utils/selectRangeColumn';
 
 const SHARED_MOUSE_TRACKER_TIMEOUT = 1000 * 30;
+export const SHARED_FOCUS_TRACKER_TIMEOUT = 1000 * 90;
+export const SHARED_DRAG_SELECT_TRACKER_TIMEOUT = 1000 * 3;
 
 export const changeHasHistoryAction = createAction<
   ActionMap[typeof ActionType.changeHasHistory]
@@ -530,6 +532,160 @@ const sharedMouseTracker: ReducerType<typeof ActionType.sharedMouseTracker> = (
   }
 };
 
+export const sharedFocusTrackerAction = createAction<
+  ActionMap[typeof ActionType.sharedFocusTracker]
+>(ActionType.sharedFocusTracker);
+
+const sharedFocusTracker: ReducerType<typeof ActionType.sharedFocusTracker> = (
+  { editor },
+  { payload: { focus }, tags, meta }
+) => {
+  if (
+    isNill(tags) ||
+    !bHas(tags, Tag.shared) ||
+    !isString(meta?.editorId) ||
+    editor.id === meta.editorId
+  ) {
+    return;
+  }
+
+  const sharedFocusTracker = editor.sharedFocusTrackerMap[meta.editorId];
+
+  if (!focus) {
+    if (sharedFocusTracker) {
+      clearTimeout(sharedFocusTracker.timeoutId);
+      Reflect.deleteProperty(editor.sharedFocusTrackerMap, meta.editorId);
+    }
+    return;
+  }
+
+  if (sharedFocusTracker) {
+    sharedFocusTracker.tableId = focus.tableId;
+    sharedFocusTracker.columnId = focus.columnId;
+    sharedFocusTracker.focusType = focus.focusType;
+
+    clearTimeout(sharedFocusTracker.timeoutId);
+    sharedFocusTracker.timeoutId = setTimeout(() => {
+      Reflect.deleteProperty(editor.sharedFocusTrackerMap, meta.editorId);
+    }, SHARED_FOCUS_TRACKER_TIMEOUT);
+  } else {
+    editor.sharedFocusTrackerMap[meta.editorId] = {
+      ...focus,
+      id: meta.editorId,
+      timeoutId: setTimeout(() => {
+        Reflect.deleteProperty(editor.sharedFocusTrackerMap, meta.editorId);
+      }, SHARED_FOCUS_TRACKER_TIMEOUT),
+    };
+  }
+};
+
+export const sharedSelectionTrackerAction = createAction<
+  ActionMap[typeof ActionType.sharedSelectionTracker]
+>(ActionType.sharedSelectionTracker);
+
+const sharedSelectionTracker: ReducerType<
+  typeof ActionType.sharedSelectionTracker
+> = ({ editor }, { payload: { selectedIds }, tags, meta }) => {
+  if (
+    isNill(tags) ||
+    !bHas(tags, Tag.shared) ||
+    !isString(meta?.editorId) ||
+    editor.id === meta.editorId
+  ) {
+    return;
+  }
+
+  const sharedSelectionTracker =
+    editor.sharedSelectionTrackerMap[meta.editorId];
+
+  if (!selectedIds.length) {
+    if (sharedSelectionTracker) {
+      clearTimeout(sharedSelectionTracker.timeoutId);
+      Reflect.deleteProperty(editor.sharedSelectionTrackerMap, meta.editorId);
+    }
+    return;
+  }
+
+  if (sharedSelectionTracker) {
+    sharedSelectionTracker.selectedIds = selectedIds;
+
+    clearTimeout(sharedSelectionTracker.timeoutId);
+    sharedSelectionTracker.timeoutId = setTimeout(() => {
+      Reflect.deleteProperty(editor.sharedSelectionTrackerMap, meta.editorId);
+    }, SHARED_FOCUS_TRACKER_TIMEOUT);
+  } else {
+    editor.sharedSelectionTrackerMap[meta.editorId] = {
+      id: meta.editorId,
+      selectedIds,
+      timeoutId: setTimeout(() => {
+        Reflect.deleteProperty(editor.sharedSelectionTrackerMap, meta.editorId);
+      }, SHARED_FOCUS_TRACKER_TIMEOUT),
+    };
+  }
+};
+
+export const sharedDragSelectTrackerAction = createAction<
+  ActionMap[typeof ActionType.sharedDragSelectTracker]
+>(ActionType.sharedDragSelectTracker);
+
+const sharedDragSelectTracker: ReducerType<
+  typeof ActionType.sharedDragSelectTracker
+> = ({ editor }, { payload: { rect }, tags, meta }) => {
+  if (
+    isNill(tags) ||
+    !bHas(tags, Tag.shared) ||
+    !isString(meta?.editorId) ||
+    editor.id === meta.editorId
+  ) {
+    return;
+  }
+
+  const sharedDragSelectTracker =
+    editor.sharedDragSelectTrackerMap[meta.editorId];
+
+  if (!rect) {
+    if (sharedDragSelectTracker) {
+      clearTimeout(sharedDragSelectTracker.timeoutId);
+      Reflect.deleteProperty(editor.sharedDragSelectTrackerMap, meta.editorId);
+    }
+    return;
+  }
+
+  if (sharedDragSelectTracker) {
+    sharedDragSelectTracker.x = rect.x;
+    sharedDragSelectTracker.y = rect.y;
+    sharedDragSelectTracker.w = rect.w;
+    sharedDragSelectTracker.h = rect.h;
+
+    clearTimeout(sharedDragSelectTracker.timeoutId);
+    sharedDragSelectTracker.timeoutId = setTimeout(() => {
+      Reflect.deleteProperty(editor.sharedDragSelectTrackerMap, meta.editorId);
+    }, SHARED_DRAG_SELECT_TRACKER_TIMEOUT);
+  } else {
+    editor.sharedDragSelectTrackerMap[meta.editorId] = {
+      ...rect,
+      id: meta.editorId,
+      timeoutId: setTimeout(() => {
+        Reflect.deleteProperty(
+          editor.sharedDragSelectTrackerMap,
+          meta.editorId
+        );
+      }, SHARED_DRAG_SELECT_TRACKER_TIMEOUT),
+    };
+  }
+};
+
+export const dragSelectRectAction = createAction<
+  ActionMap[typeof ActionType.dragSelectRect]
+>(ActionType.dragSelectRect);
+
+const dragSelectRect: ReducerType<typeof ActionType.dragSelectRect> = (
+  { editor },
+  { payload: { rect } }
+) => {
+  editor.dragSelect = rect;
+};
+
 export const validationIdsAction = createAction<
   ActionMap[typeof ActionType.validationIds]
 >(ActionType.validationIds);
@@ -657,6 +813,10 @@ export const editorReducers = {
   [ActionType.dragstartColumn]: dragstartColumn,
   [ActionType.dragendColumn]: dragendColumn,
   [ActionType.sharedMouseTracker]: sharedMouseTracker,
+  [ActionType.sharedFocusTracker]: sharedFocusTracker,
+  [ActionType.sharedSelectionTracker]: sharedSelectionTracker,
+  [ActionType.sharedDragSelectTracker]: sharedDragSelectTracker,
+  [ActionType.dragSelectRect]: dragSelectRect,
   [ActionType.validationIds]: validationIds,
   [ActionType.getLWW]: getLWW,
   [ActionType.mergeLWW]: mergeLWW,
@@ -689,6 +849,10 @@ export const actions = {
   dragstartColumnAction,
   dragendColumnAction,
   sharedMouseTrackerAction,
+  sharedFocusTrackerAction,
+  sharedSelectionTrackerAction,
+  sharedDragSelectTrackerAction,
+  dragSelectRectAction,
   validationIdsAction,
   getLWWAction,
   mergeLWWAction,

--- a/packages/erd-editor/src/engine/modules/editor/state.test.ts
+++ b/packages/erd-editor/src/engine/modules/editor/state.test.ts
@@ -37,6 +37,10 @@ describe('editor/state', () => {
       expect(editor.draggableColumn).toBeNull();
       expect(editor.draggingColumnMap).toEqual({});
       expect(editor.sharedMouseTrackerMap).toEqual({});
+      expect(editor.sharedFocusTrackerMap).toEqual({});
+      expect(editor.sharedSelectionTrackerMap).toEqual({});
+      expect(editor.sharedDragSelectTrackerMap).toEqual({});
+      expect(editor.dragSelect).toBeNull();
     });
 
     it('gives each editor its own id and its own mutable containers', () => {
@@ -58,6 +62,27 @@ describe('editor/state', () => {
         nickname: 'user',
         timeoutId: null,
       };
+      a.sharedFocusTrackerMap['e1'] = {
+        id: 'e1',
+        tableId: 't1',
+        columnId: 'c1',
+        focusType: FocusType.columnName,
+        timeoutId: null,
+      };
+      a.sharedSelectionTrackerMap['e1'] = {
+        id: 'e1',
+        selectedIds: ['m1', 't1'],
+        timeoutId: null,
+      };
+      a.sharedDragSelectTrackerMap['e1'] = {
+        id: 'e1',
+        x: 10,
+        y: 20,
+        w: 200,
+        h: 100,
+        timeoutId: null,
+      };
+      a.dragSelect = { x: 5, y: 6, w: 70, h: 80 };
 
       expect(b.selectedMap).toEqual({});
       expect(b.viewport.width).toBe(DEFAULT_WIDTH);
@@ -66,6 +91,10 @@ describe('editor/state', () => {
       expect(b.draggingColumnMap).toEqual({});
       expect(b.hoverRelationshipMap).toEqual({});
       expect(b.sharedMouseTrackerMap).toEqual({});
+      expect(b.sharedFocusTrackerMap).toEqual({});
+      expect(b.sharedSelectionTrackerMap).toEqual({});
+      expect(b.sharedDragSelectTrackerMap).toEqual({});
+      expect(b.dragSelect).toBeNull();
     });
 
     it('is the shape the real store starts from and mutates', () => {

--- a/packages/erd-editor/src/engine/modules/editor/state.ts
+++ b/packages/erd-editor/src/engine/modules/editor/state.ts
@@ -2,6 +2,7 @@ import { arrayHas, nanoid } from '@dineug/shared';
 
 import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '@/constants/layout';
 import { Point, ValuesType } from '@/internal-types';
+import { Rect } from '@/utils/dragSelect';
 
 export type Editor = {
   id: string;
@@ -17,6 +18,10 @@ export type Editor = {
   draggableColumn: DraggableColumn | null;
   draggingColumnMap: Record<string, boolean>;
   sharedMouseTrackerMap: Record<string, SharedMouseTracker>;
+  sharedFocusTrackerMap: Record<string, SharedFocusTracker>;
+  sharedSelectionTrackerMap: Record<string, SharedSelectionTracker>;
+  sharedDragSelectTrackerMap: Record<string, SharedDragSelectTracker>;
+  dragSelect: Rect | null;
 };
 
 export type Viewport = {
@@ -53,6 +58,28 @@ export type SharedMouseTracker = {
   x: number;
   y: number;
   nickname: string;
+  timeoutId: any;
+};
+
+export type SharedFocus = {
+  tableId: string;
+  columnId: string | null;
+  focusType: FocusType;
+};
+
+export type SharedFocusTracker = SharedFocus & {
+  id: string;
+  timeoutId: any;
+};
+
+export type SharedSelectionTracker = {
+  id: string;
+  selectedIds: string[];
+  timeoutId: any;
+};
+
+export type SharedDragSelectTracker = Rect & {
+  id: string;
   timeoutId: any;
 };
 
@@ -102,4 +129,8 @@ export const createEditor = (): Editor => ({
   draggableColumn: null,
   draggingColumnMap: {},
   sharedMouseTrackerMap: {},
+  sharedFocusTrackerMap: {},
+  sharedSelectionTrackerMap: {},
+  sharedDragSelectTrackerMap: {},
+  dragSelect: null,
 });

--- a/packages/erd-editor/src/engine/rx-operators/sharedStreamActionsCompressor.test.ts
+++ b/packages/erd-editor/src/engine/rx-operators/sharedStreamActionsCompressor.test.ts
@@ -9,7 +9,13 @@ import {
   vi,
 } from 'vite-plus/test';
 
-import { sharedMouseTrackerAction } from '@/engine/modules/editor/atom.actions';
+import {
+  sharedDragSelectTrackerAction,
+  sharedFocusTrackerAction,
+  sharedMouseTrackerAction,
+  sharedSelectionTrackerAction,
+} from '@/engine/modules/editor/atom.actions';
+import { FocusType } from '@/engine/modules/editor/state';
 import { moveMemoAction } from '@/engine/modules/memo/atom.actions';
 import { streamZoomLevelAction } from '@/engine/modules/settings/atom.actions';
 import {
@@ -59,11 +65,100 @@ describe('sharedStreamActionsCompressor', () => {
     expect(emitted).toHaveLength(1);
 
     vi.advanceTimersByTime(100);
-    source$.next([sharedMouseTrackerAction({ x: 4, y: 4 })]);
 
     expect(emitted).toEqual([
       [sharedMouseTrackerAction({ x: 1, y: 1 })],
-      [sharedMouseTrackerAction({ x: 4, y: 4 })],
+      [sharedMouseTrackerAction({ x: 3, y: 3 })],
+    ]);
+  });
+
+  it('delivers the last action of a burst instead of stranding it in the buffer', () => {
+    const { source$, emitted } = createHarness();
+
+    source$.next([sharedMouseTrackerAction({ x: 1, y: 1 })]);
+    source$.next([sharedMouseTrackerAction({ x: 2, y: 2 })]);
+    source$.next([sharedMouseTrackerAction({ x: 3, y: 3 })]);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(emitted.at(-1)).toEqual([sharedMouseTrackerAction({ x: 3, y: 3 })]);
+  });
+
+  it('delivers a terminal shared focus action so a peer never keeps a stale marker', () => {
+    const { source$, emitted } = createHarness();
+    const move = sharedFocusTrackerAction({
+      focus: {
+        tableId: 't1',
+        columnId: 'c1',
+        focusType: FocusType.columnName,
+      },
+    });
+    const clear = sharedFocusTrackerAction({ focus: null });
+
+    source$.next([move]);
+    source$.next([clear]);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(emitted.at(-1)).toEqual([clear]);
+  });
+
+  it('delivers a terminal shared drag select action so a peer never keeps a phantom marquee', () => {
+    const { source$, emitted } = createHarness();
+    const drag = sharedDragSelectTrackerAction({
+      rect: { x: 10, y: 20, w: 200, h: 100 },
+    });
+    const clear = sharedDragSelectTrackerAction({ rect: null });
+
+    source$.next([drag]);
+    source$.next([clear]);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(emitted.at(-1)).toEqual([clear]);
+  });
+
+  it('groups every shared tracker by its own type, so a regroup alias over them would drop whole presence channels', () => {
+    const { source$, emitted } = createHarness();
+    const focus1 = sharedFocusTrackerAction({
+      focus: { tableId: 't1', columnId: null, focusType: FocusType.tableName },
+    });
+    const focus2 = sharedFocusTrackerAction({
+      focus: {
+        tableId: 't1',
+        columnId: 'c1',
+        focusType: FocusType.columnName,
+      },
+    });
+    const selection1 = sharedSelectionTrackerAction({ selectedIds: ['t1'] });
+    const selection2 = sharedSelectionTrackerAction({
+      selectedIds: ['m1', 't1'],
+    });
+    const dragSelect1 = sharedDragSelectTrackerAction({
+      rect: { x: 0, y: 0, w: 10, h: 10 },
+    });
+    const dragSelect2 = sharedDragSelectTrackerAction({
+      rect: { x: 0, y: 0, w: 20, h: 20 },
+    });
+
+    source$.next([
+      sharedMouseTrackerAction({ x: 1, y: 1 }),
+      focus1,
+      selection1,
+      dragSelect1,
+      sharedMouseTrackerAction({ x: 2, y: 2 }),
+      focus2,
+      selection2,
+      dragSelect2,
+    ]);
+
+    vi.advanceTimersByTime(100);
+
+    expect(emitted).toEqual([
+      [sharedMouseTrackerAction({ x: 2, y: 2 })],
+      [focus2],
+      [selection2],
+      [dragSelect2],
     ]);
   });
 

--- a/packages/erd-editor/src/engine/rx-operators/sharedStreamActionsCompressor.ts
+++ b/packages/erd-editor/src/engine/rx-operators/sharedStreamActionsCompressor.ts
@@ -20,7 +20,11 @@ export const sharedStreamActionsCompressor = (
   source$: Observable<Array<AnyAction>>
 ) =>
   source$.pipe(
-    groupByStreamActions(SharedStreamActionTypes, [], throttleTime(100)),
+    groupByStreamActions(
+      SharedStreamActionTypes,
+      [],
+      throttleTime(100, undefined, { leading: true, trailing: true })
+    ),
     map(actions =>
       hasSharedStreamActionTypes(actions[0]?.type)
         ? [last(actions) as AnyAction]

--- a/packages/erd-editor/src/engine/shared-store.test.ts
+++ b/packages/erd-editor/src/engine/shared-store.test.ts
@@ -331,16 +331,17 @@ describe('createSharedStore', () => {
 
     // leading emission of the 100ms throttle window
     track(1);
-    // throttled: buffered until the window reopens
+    // throttled: buffered until the trailing edge closes the window
     track(2);
     track(3);
     vi.advanceTimersByTime(150);
     track(4);
+    vi.advanceTimersByTime(150);
 
     const trackers = fixture.seen
       .flat()
       .filter(action => action.type === 'editor.sharedMouseTracker');
-    expect(trackers.map(action => action.payload.x)).toEqual([1, 4]);
+    expect(trackers.map(action => action.payload.x)).toEqual([1, 3, 4]);
   });
 
   it('destroy tears down its own subscriptions and leaves the borrowed store alive', () => {

--- a/packages/erd-editor/src/styles/emittedCss.regression.test.ts
+++ b/packages/erd-editor/src/styles/emittedCss.regression.test.ts
@@ -185,17 +185,19 @@ describe('rule-count invariance', () => {
     expect(modulePaths).toHaveLength(62);
   });
 
-  it('adopts 617 rules, none of them a duplicate', () => {
+  it('adopts 622 rules, none of them a duplicate', () => {
     // 302 -> 609: the color picker fold, +307. It rendered into a tree `<style>` before, so none
     // of its rules were adopted and none of them were counted here; as a `css.global` literal all
     // 307 are. 609 -> 611: the Alt+drag ghost's two scoped rules. 611 -> 617: the CodeBlock
     // overlay, which splits its one `code` rule into a shared alignment fragment, a scroller, a
-    // layer box, a preview and its `*` block, and a textarea with its `::selection`.
-    expect(cumulative).toHaveLength(617);
-    expect(new Set(cumulative).size).toBe(617);
+    // layer box, a preview and its `*` block, and a textarea with its `::selection`. 617 -> 622:
+    // the five collaborative presence rules, all nested into existing templates rather than
+    // modules of their own — which is why the sheet count below did not move with them.
+    expect(cumulative).toHaveLength(622);
+    expect(new Set(cumulative).size).toBe(622);
   });
 
-  it('splits into 327 global rules ahead of 290 component rules', () => {
+  it('splits into 327 global rules ahead of 295 component rules', () => {
     // P4 moved reset (12), fonts (1), typography (1) and scrollbar (6) out of tree `<style>`
     // elements and into `adoptedStyleSheets`. A shadow root applies its own `styleSheets` before
     // its `adoptedStyleSheets`, so the only thing keeping the reset ahead of the components now
@@ -207,10 +209,12 @@ describe('rule-count invariance', () => {
     // then went 158 -> 160 sheets and 282 -> 284 rules on its own account, when the Alt+drag
     // ghost added its layer and per-entity templates; the global half did not move with it,
     // which is the same statement in the other direction. 160 -> 164 sheets / 284 -> 290 rules is
-    // the CodeBlock overlay, on the same terms.
+    // the CodeBlock overlay, on the same terms. 290 -> 295 is collaborative presence, with the
+    // sheet count unmoved — the one thing that says those rules nested into existing templates
+    // instead of adding a module.
     expect(sheetsOfEachKind).toEqual({ global: 5, component: 164 });
     expect(globalRules).toHaveLength(327);
-    expect(componentRules).toHaveLength(290);
+    expect(componentRules).toHaveLength(295);
     expect(cumulative).toEqual([...globalRules, ...componentRules]);
   });
 
@@ -227,7 +231,7 @@ describe('rule-count invariance', () => {
     // Identifiers are content hashes now, so a rule's text is the same whether its module is
     // rendered alone or with the other 61 — which is exactly what makes this comparison mean
     // "nothing was lost to dedup" rather than "the class names differ".
-    expect(union.size).toBe(617);
+    expect(union.size).toBe(622);
     expect(droppedByLoadingTogether).toEqual([]);
   });
 

--- a/packages/erd-editor/src/utils/focus.test.ts
+++ b/packages/erd-editor/src/utils/focus.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { FocusTable, FocusType } from '@/engine/modules/editor/state';
+import {
+  FocusTable,
+  FocusType,
+  SharedFocus,
+} from '@/engine/modules/editor/state';
 import {
   isEdit,
   isFocus,
   isSelectColumn,
   lastCursorFocus,
+  toSharedFocus,
+  toSharedFocusKey,
 } from '@/utils/focus';
 
 const createFocusTable = (value?: Partial<FocusTable>): FocusTable => ({
@@ -15,6 +21,13 @@ const createFocusTable = (value?: Partial<FocusTable>): FocusTable => ({
   selectColumnIds: [],
   prevSelectColumnId: null,
   edit: false,
+  ...value,
+});
+
+const createSharedFocus = (value?: Partial<SharedFocus>): SharedFocus => ({
+  tableId: 'table-1',
+  columnId: null,
+  focusType: FocusType.tableName,
   ...value,
 });
 
@@ -82,6 +95,20 @@ describe('isFocus', () => {
 
     expect(
       isFocus(focusTable, FocusType.columnUnique, 'table-1', 'column-1')
+    ).toBe(false);
+  });
+
+  it('accepts a shared focus without the selection and edit fields', () => {
+    const sharedFocus = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: 'column-1',
+    });
+
+    expect(
+      isFocus(sharedFocus, FocusType.columnName, 'table-1', 'column-1')
+    ).toBe(true);
+    expect(
+      isFocus(sharedFocus, FocusType.columnName, 'table-1', 'column-2')
     ).toBe(false);
   });
 });
@@ -209,5 +236,95 @@ describe('lastCursorFocus', () => {
     expect(document.activeElement).toBe(input);
 
     input.remove();
+  });
+});
+
+describe('toSharedFocus', () => {
+  it('returns null when there is no focus table', () => {
+    expect(toSharedFocus(null)).toBe(null);
+  });
+
+  it('keeps only the table id, the column id and the focus type', () => {
+    const sharedFocus = toSharedFocus(
+      createFocusTable({
+        focusType: FocusType.columnDataType,
+        columnId: 'column-1',
+        selectColumnIds: ['column-1', 'column-2'],
+        prevSelectColumnId: 'column-2',
+        edit: true,
+      })
+    );
+
+    expect(sharedFocus).toEqual({
+      tableId: 'table-1',
+      columnId: 'column-1',
+      focusType: FocusType.columnDataType,
+    });
+    expect(Object.keys(sharedFocus ?? {})).toHaveLength(3);
+  });
+
+  it('produces the same key when only the selection and edit fields change', () => {
+    const focusTable = createFocusTable({
+      focusType: FocusType.columnName,
+      columnId: 'column-1',
+    });
+    const editing = createFocusTable({
+      focusType: FocusType.columnName,
+      columnId: 'column-1',
+      selectColumnIds: ['column-1'],
+      prevSelectColumnId: 'column-1',
+      edit: true,
+    });
+
+    expect(toSharedFocusKey(toSharedFocus(focusTable))).toBe(
+      toSharedFocusKey(toSharedFocus(editing))
+    );
+  });
+});
+
+describe('toSharedFocusKey', () => {
+  it('returns an empty string when there is no focus', () => {
+    expect(toSharedFocusKey(null)).toBe('');
+  });
+
+  it('separates focuses that only differ in the column id', () => {
+    const columnA = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: 'column-1',
+    });
+    const columnB = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: 'column-2',
+    });
+
+    expect(toSharedFocusKey(columnA)).not.toBe(toSharedFocusKey(columnB));
+  });
+
+  it('separates focuses that only differ in the focus type', () => {
+    const name = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: 'column-1',
+    });
+    const dataType = createSharedFocus({
+      focusType: FocusType.columnDataType,
+      columnId: 'column-1',
+    });
+
+    expect(toSharedFocusKey(name)).not.toBe(toSharedFocusKey(dataType));
+  });
+
+  it('separates a null column id from an empty string column id', () => {
+    const nullColumn = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: null,
+    });
+    const emptyColumn = createSharedFocus({
+      focusType: FocusType.columnName,
+      columnId: '',
+    });
+
+    expect(toSharedFocusKey(nullColumn)).not.toBe(
+      toSharedFocusKey(emptyColumn)
+    );
   });
 });

--- a/packages/erd-editor/src/utils/focus.ts
+++ b/packages/erd-editor/src/utils/focus.ts
@@ -1,7 +1,11 @@
-import { FocusTable, FocusType } from '@/engine/modules/editor/state';
+import {
+  FocusTable,
+  FocusType,
+  SharedFocus,
+} from '@/engine/modules/editor/state';
 
 export function isFocus(
-  focusTable: FocusTable | null,
+  focusTable: Pick<FocusTable, 'tableId' | 'columnId' | 'focusType'> | null,
   focusType: FocusType,
   tableId: string,
   columnId: string | null = null
@@ -52,3 +56,17 @@ export function lastCursorFocus(input: HTMLInputElement) {
   input.selectionEnd = len;
   input.focus();
 }
+
+export const toSharedFocus = (
+  focusTable: FocusTable | null
+): SharedFocus | null =>
+  focusTable
+    ? {
+        tableId: focusTable.tableId,
+        columnId: focusTable.columnId,
+        focusType: focusTable.focusType,
+      }
+    : null;
+
+export const toSharedFocusKey = (focus: SharedFocus | null) =>
+  focus ? JSON.stringify([focus.tableId, focus.columnId, focus.focusType]) : '';

--- a/packages/erd-editor/src/utils/sharedColor.test.ts
+++ b/packages/erd-editor/src/utils/sharedColor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { Palette } from '@/themes/radix-ui-theme';
+import { SharedColors, toSharedColor } from '@/utils/sharedColor';
+
+describe('SharedColors', () => {
+  it('lists eight distinct opaque colors', () => {
+    expect(SharedColors).toHaveLength(8);
+    expect(new Set(SharedColors).size).toBe(SharedColors.length);
+
+    for (const color of SharedColors) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('reads the same value in both appearances', () => {
+    const lightValues = Object.entries(Palette)
+      .filter(([key]) => !key.includes('Dark') && !key.endsWith('A'))
+      .flatMap(([, scale]) => Object.values(scale as Record<string, string>));
+    const darkValues = Object.entries(Palette)
+      .filter(([key]) => key.endsWith('Dark'))
+      .flatMap(([, scale]) => Object.values(scale as Record<string, string>));
+
+    for (const color of SharedColors) {
+      expect(lightValues).toContain(color);
+      expect(darkValues).toContain(color);
+    }
+  });
+
+  it('avoids the colors the editor already spends on key badges', () => {
+    expect(SharedColors).not.toContain(Palette.amber.amber9);
+    expect(SharedColors).not.toContain(Palette.ruby.ruby9);
+    expect(SharedColors).not.toContain(Palette.cyan.cyan9);
+  });
+});
+
+describe('toSharedColor', () => {
+  it('is deterministic for one id', () => {
+    expect(toSharedColor('editor-1')).toBe(toSharedColor('editor-1'));
+  });
+
+  it('always lands inside the palette, including for an empty id', () => {
+    for (const id of ['', 'a', 'V1StGXR8_Z5jdHi6B-myT', '\u{1F600}\u{1F600}']) {
+      expect(SharedColors).toContain(toSharedColor(id));
+    }
+  });
+
+  it('spreads nanoid-shaped ids across every slot', () => {
+    const ids = Array.from({ length: 400 }, (_, index) => `editor-${index}`);
+    const used = new Set(ids.map(toSharedColor));
+
+    expect(used.size).toBe(SharedColors.length);
+  });
+
+  it('separates two peers in a session more often than not', () => {
+    const pairs = Array.from({ length: 100 }, (_, index) => [
+      `peer-a-${index}`,
+      `peer-b-${index}`,
+    ]);
+    const distinct = pairs.filter(
+      ([a, b]) => toSharedColor(a) !== toSharedColor(b)
+    );
+
+    expect(distinct.length).toBeGreaterThan(70);
+  });
+});

--- a/packages/erd-editor/src/utils/sharedColor.ts
+++ b/packages/erd-editor/src/utils/sharedColor.ts
@@ -1,0 +1,28 @@
+import { get } from 'es-toolkit/compat';
+
+import { Palette } from '@/themes/radix-ui-theme';
+
+const SharedColorHues = [
+  'tomato',
+  'gold',
+  'grass',
+  'teal',
+  'iris',
+  'purple',
+  'plum',
+  'pink',
+] as const;
+
+export const SharedColors: ReadonlyArray<string> = SharedColorHues.map(
+  hue => get(Palette, `${hue}.${hue}9`) ?? ''
+);
+
+export function toSharedColor(id: string): string {
+  let hash = 0;
+
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+
+  return SharedColors[Math.abs(hash) % SharedColors.length];
+}

--- a/packages/intellij-webview/AGENTS.md
+++ b/packages/intellij-webview/AGENTS.md
@@ -55,7 +55,7 @@ cd ../intellij-plugin && ./gradlew runIde
 
 - Mirror of `packages/vscode-webview/src/index.ts` — diff both when either moves. The same two gaps: no `setImportFileCallback`, so the element's own file input is what imports here and the mirrored `webviewImportFileCommand` handler goes unreached while `ErdEditor.kt` no-ops `ImportFile`; and `auto` appearance resolves to dark instead of following the host.
 - Register commands up front, collecting disposers with `Bridge.mergeRegister`; a new command belongs in the bridge package, not a fork.
-- The shared store is created with `mouseTracker: false` — it exists for host replication only.
+- The shared store is created with `mouseTracker: false, focusTracker: false` — it exists for host replication only.
 
 ## Dependencies
 

--- a/packages/intellij-webview/src/main.ts
+++ b/packages/intellij-webview/src/main.ts
@@ -25,7 +25,10 @@ import { encode } from 'base64-arraybuffer';
 const bridge = new Bridge();
 const workerBridge = new Bridge();
 const editor = document.createElement('erd-editor');
-const sharedStore = editor.getSharedStore({ mouseTracker: false });
+const sharedStore = editor.getSharedStore({
+  mouseTracker: false,
+  focusTracker: false,
+});
 const replicationStoreWorker = new Worker(
   new URL('./services/replicationStore.worker.ts', import.meta.url),
   {

--- a/packages/vscode-webview/AGENTS.md
+++ b/packages/vscode-webview/AGENTS.md
@@ -53,7 +53,7 @@ replication-store worker holding the host's copy. It builds *into* `../vscode-ex
 
 - Two `Bridge` instances — `bridge` for host ↔ webview, `workerBridge` for webview ↔ replication worker.
   Handlers are registered up front and collected with `Bridge.mergeRegister`.
-- `editor.getSharedStore({ mouseTracker: false })` — that store feeds host replication, not collaboration;
+- `editor.getSharedStore({ mouseTracker: false, focusTracker: false })` — that store feeds host replication, not collaboration;
   nothing here receives cursor positions.
 - Shiki loads lazily into its own chunk; `#loading` is removed and the editor appended to `document.body`
   only when `webviewInitialValueCommand` arrives.

--- a/packages/vscode-webview/README.md
+++ b/packages/vscode-webview/README.md
@@ -27,7 +27,7 @@ shares with the extension host:
   `@dineug/erd-editor-vscode-replication-store-worker`, which keeps a headless
   replica of the document.
 
-`editor.getSharedStore({ mouseTracker: false })` is subscribed once the host
+`editor.getSharedStore({ mouseTracker: false, focusTracker: false })` is subscribed once the host
 sends the initial value; every batch of actions is forwarded to both the worker
 and the host. File dialogs belong to the host — `setImportFileCallback` and
 `setExportFileCallback` dispatch host commands, and export blobs are

--- a/packages/vscode-webview/src/index.ts
+++ b/packages/vscode-webview/src/index.ts
@@ -30,7 +30,10 @@ const bridge = new Bridge();
 const workerBridge = new Bridge();
 const vscode = acquireVsCodeApi();
 const editor = document.createElement('erd-editor');
-const sharedStore = editor.getSharedStore({ mouseTracker: false });
+const sharedStore = editor.getSharedStore({
+  mouseTracker: false,
+  focusTracker: false,
+});
 const replicationStoreWorker = new ReplicationStoreWorker({
   name: '@dineug/erd-editor-vscode-webview/replication-store-worker',
 });


### PR DESCRIPTION
A shared session only surfaced peers' mouse cursors. It now shows what everyone is actually working on: the table and cell they have focused, everything they have selected, and the marquee they are dragging right now.

Three markers, all in that peer's own color:

- **Focus** — a 1px outline on the table, plus an underline on the exact cell (table name/comment, or any of the seven column cells).
- **Selection** — a 1px ring on every table *and memo* they hold, so a multi-select is visible as a whole.
- **Drag box** — their live `$mod`+drag marquee, drawn in absolute canvas space next to the cursor that is dragging it.

`getSharedStore(config)` gains `focusTracker?: boolean` beside the existing `mouseTracker`, defaulting to `true` and gating all three channels:

```js
const sharedStore = editor.getSharedStore({
  getNickname: () => nickname,
  mouseTracker: true,
  focusTracker: true,   // new
});
```

The two IDE webviews opt out — their shared store exists for host replication and has no peer to render anything.

## Peers are identified by color, not a second badge

The cursor already carries the nickname, so a badge on every marker would be redundant noise. Instead `toSharedColor(editorId)` hashes into eight radix **step-9** hues — the one step whose value is byte-identical in light and dark, so the palette needs no theme token and works in both appearances unchanged. `amber` / `ruby` / `cyan` are excluded because the PK/FK/PFK badges already spend them.

One color paints a peer's cursor, focus outline, selection ring and marquee, which is what makes the four read as one person. The cursor had **no** per-peer color before this — every remote cursor inherited the same foreground — so with two collaborators you could only tell them apart by reading the nickname text.

## Three action types, not one presence blob

`editor.sharedFocusTracker`, `editor.sharedSelectionTracker` and `editor.sharedDragSelectTracker` are each registered **only** in `SharedStreamActionTypes`. They ride the shared pipe but stay out of `ChangeActionTypes`, and therefore out of LWW, undo/redo, the replication store and `toJson`.

Merging them into one presence payload was the first design tried, and it is wrong: `focusTable` and `selectedMap` are independent state, so a single `{focus: null}` clear would wrongly erase a peer's selection. Separate types also get separate throttle windows and cannot cannibalise each other.

Remote presence can never move local state — the local `editor.select*` / focus actions are in no shared list, so they never leave the tab, and the three reducers write only their own tracker maps behind the same `Tag.shared` + foreign-`editorId` guard the mouse tracker already uses.

## Where the local state is observed

Focus and selection come from one `store.subscribe` callback rather than an action filter, because `removeTableAction$` and `editor.loadJson` invalidate both **without dispatching a focus or select action**. Selection goes out as a *sorted* id array: `select` merges through `Object.assign` while `selectAll` reassigns, so the same set arrives in different key orders and an unsorted dedupe key would flap on every click.

The drag rect could not be observed that way at all — `DragSelect` keeps it in component-local state and `dragSelectAction$` closes over it without putting it in any dispatched payload. It now also dispatches a local-only `editor.dragSelectRect`, which is in no classification list, so the one gated broadcaster can see it and the feature keeps a single config flag instead of copying the mouse tracker's four-file emitter chain.

## Expiry differs per channel, because the signals differ

Focus and selection are latched, so they carry a 90s liveness timeout refreshed by a 30s heartbeat. Without the heartbeat a peer reading one cell for five minutes would lose their marker and never get it back, since the dedupe key suppresses a resend.

A drag can end with no signal at all — button released outside the window, tab closed — so its box expires after 3s with a 1s heartbeat. The deterministic paths still clear it in one round trip from `DragSelect`'s teardown; the timeout is the backstop, not the UX path.

## Marker geometry

The table root already owns `border` twice (its own, and local selection), so peer focus uses `outline` and peer selection a `box-shadow` ring — neither contends, and neither costs layout. Both are 1px at the same radius, and the ring is **suppressed while the outline is present**: clicking a table sets focus and selection together, and two rings in one color read as a doubled line.

## One pre-existing defect, fixed here because the feature exposes it

`sharedStreamActionsCompressor` closed its per-type buffer with a leading-only `throttleTime(100)`:

```ts
groupByStreamActions(SharedStreamActionTypes, [], throttleTime(100)),
map(actions => hasSharedStreamActionTypes(actions[0]?.type)
  ? [last(actions) as AnyAction]
  : actions),
```

`buffer` is flushed only when the notifier emits, and a leading-edge throttle emits only when a *later* action of that type arrives — so **the final action of every burst was stranded forever**. Reproduced against the repo's rxjs with six emissions 30ms apart: `[[0], [1,2,3,4]]`, with `5` never delivered.

A resampled cursor hides that; latched state does not. Walking a column list with the arrow keys left peers underlining a cell the user had already left, and an Escape within 100ms of the last move stranded the `{focus: null}` clear, so the outline sat on a table nobody was in. Enabling the trailing edge delivers each window's last action — and fixes the cursor's own final position, which was quietly up to 100ms behind.

## Testing

- **+78 unit tests**, 353 files / 6016 total green, covering the reducers' guards and timer hygiene, the sorted-selection dedupe, per-channel heartbeats, the `focusTracker: false` opt-out silencing all three channels, and the marker attributes and colors on Table, HighLevelTable and Memo.
- **4 e2e specs** in `shared-presence.spec.ts` drive the real transport — a second `<erd-editor>` cross-wired through `getSharedStore` — rather than mocking it. Removing the two new types from `SharedStreamActionTypes` fails exactly the two new specs; reverting the compressor fix fails the burst spec with the marker stuck on the wrong cell.
- Verified visually in both light and dark: a peer's outline, cell underline, selection ring, marquee and cursor all render in one matching color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Apk8KotgSzdECCCdvjGda1
